### PR TITLE
arm64: dts: qcom: sdm625-xiaomi-daisy: New nodes for audio, also added missing s regulators and volume-up button

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
@@ -57,6 +57,22 @@
 			status = "okay";
 		};*/
 	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&gpio_key_default>;
+
+		label = "GPIO Button";
+
+		volume-up {
+			label = "Volume Up";
+			gpios = <&msmgpio 85 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+		};
+	};
+
 };
 
 &usb3 {
@@ -70,6 +86,21 @@
 };
 
 &smd_rpm_regulators {
+	s1 {
+		regulator-min-microvolt = <863000>;
+		regulator-max-microvolt = <1152000>;
+	};
+
+	s3 {
+		regulator-min-microvolt = <1224000>;
+		regulator-max-microvolt = <1224000>;
+	};
+
+	s4 {
+		regulator-min-microvolt = <1896000>;
+		regulator-max-microvolt = <2048000>;
+    };
+
 	l1 {
 		regulator-min-microvolt = <1000000>;
 		regulator-max-microvolt = <1100000>;
@@ -190,6 +221,54 @@
 	};
 };
 
+&i2c_2 {
+	status = "okay";
+	speaker_codec: spkamp@3a {/* max98927 smartpa device*/
+		compatible = "maxim,max98927";
+		status = "okay";
+		reg = <0x3a>;
+		vmon-slot-no = <1>;
+		imon-slot-no = <1>;
+		interleave_mode = <0>;
+		#sound-dai-cells = <0>;
+
+		pinctrl-names = "reset";
+		pinctrl-0 = <&spk_ext_pa_reset>;
+	};
+};
+
+&sound_card {
+	status = "okay";
+
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&cdc_pdm_lines_act &cdc_pdm_lines_2_act &cdc_pdm_comp_lines_act &pri_tlmm_default>;
+	pinctrl-1 = <&cdc_pdm_lines_sus &cdc_pdm_lines_2_sus &cdc_pdm_comp_lines_act &pri_tlmm_default>;
+
+	model = "xiaomi-mi-a2-lite";
+
+	quinary-mi2s-dai-link {
+		link-name = "Quinary MI2S";
+		cpu {
+			sound-dai = <&q6afedai QUINARY_MI2S_RX>;
+		};
+
+		platform {
+			sound-dai = <&q6routing>;
+		};
+
+		codec {
+			sound-dai = <&speaker_codec>;
+		};
+	};
+};
+
+&q6afedai {
+	dai@127 {
+		reg = <QUINARY_MI2S_RX>;
+		qcom,sd-lines = <0>;
+	};
+};
+
 &i2c_3 {
 	status = "okay";
 
@@ -266,6 +345,13 @@
 &msmgpio {
 	gpio-reserved-ranges = <0 4>, <16 4>, <135 4>;
 
+	pri_tlmm_default: pri-tlmm-pins {
+		pins = "gpio88", "gpio91", "gpio93";
+		function = "pri_mi2s";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
 	pmx_mdss_default: pmx-mdss-default-pins {
 		pins = "gpio61", "gpio59";
 		function = "gpio";
@@ -341,5 +427,19 @@
 		function = "gpio";
 		drive-strength = <2>;
 		bias-pull-down;
+	};
+
+	spk_ext_pa_default: speaker-amp-pins {
+		pins = "gpio89";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	spk_ext_pa_reset: speaker-amp-pins {
+		pins = "gpio89";
+		function = "gpio";
+		drive-strength = <0>;
+		bias-disable;
 	};
 };


### PR DESCRIPTION
The DT for daisy was missing the nodes for s* regulators so they had no voltage and current set. This prevented the modem from booting and caused some other issues.
I also added basic audio nodes, but there's still work to do.
And i finally added the volume-up button.