### PR TITLE
Fixes and new features for daisy

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
@@ -76,6 +76,23 @@
 		voltage-min-design-microvolt = <3400000>;
 		voltage-max-design-microvolt = <4400000>;
 	};
+
+	sensors: i2c@0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&msmgpio 14 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&msmgpio 15 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;        /* ~100 kHz */
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		lsm6dsl@6a {
+			compatible = "st,lsm6dsl";
+			reg = <0x6a>;
+			mount-matrix = "-1", "0", "0",
+					"0", "-1", "0",
+					"0", "0", "1";
+		};
+	};
 };
 
 &pmi8950_fg {

--- a/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
@@ -321,7 +321,7 @@
 	pinctrl-0 = <&sdc2_clk_on &sdc2_cmd_on &sdc2_data_on &sdc2_cd_on>;
 	pinctrl-1 = <&sdc2_clk_off &sdc2_cmd_off &sdc2_data_off &sdc2_cd_off>;
 
-	cd-gpios = <&msmgpio 133 GPIO_ACTIVE_LOW>;
+	cd-gpios = <&msmgpio 133 GPIO_ACTIVE_HIGH>;
 };
 
 &msmgpio {

--- a/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
@@ -70,6 +70,20 @@
 		};
 	};
 
+	battery: battery {
+		compatible = "simple-battery";
+		charge-full-design-microamp-hours = <4000000>;
+		voltage-min-design-microvolt = <3400000>;
+		voltage-max-design-microvolt = <4400000>;
+	};
+};
+
+&pmi8950_fg {
+	monitored-battery = <&battery>;
+};
+
+&pmi8950_smbcharger {
+	monitored-battery = <&battery>;
 };
 
 &usb3 {

--- a/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
@@ -355,6 +355,19 @@
 	cd-gpios = <&msmgpio 133 GPIO_ACTIVE_HIGH>;
 };
 
+&flash_leds {
+	status = "okay";
+	led0 {
+		reg = <0>;
+		color = <LED_COLOR_ID_WHITE>;
+		led-sources = <0>;
+		function = LED_FUNCTION_FLASH;
+		flash-max-microamp = <1000000>;
+		flash-max-timeout-us = <1280000>;
+		led-max-microamp = <200000>;
+	};
+};
+
 &msmgpio {
 	gpio-reserved-ranges = <0 4>, <16 4>, <135 4>;
 

--- a/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/sdm625-xiaomi-daisy.dts
@@ -273,8 +273,6 @@
 
 	model = "xiaomi-daisy";
 
-	model = "xiaomi-mi-a2-lite";
-
 	quinary-mi2s-dai-link {
 		link-name = "Quinary MI2S";
 		cpu {
@@ -292,9 +290,9 @@
 };
 
 &q6afedai {
-	dai@22 {
+	dai@127 {
 		reg = <QUINARY_MI2S_RX>;
-		qcom,sd-lines = <1>;
+		qcom,sd-lines = <0>;
 	};
 };
 

--- a/drivers/gpu/drm/panel/Kconfig
+++ b/drivers/gpu/drm/panel/Kconfig
@@ -660,9 +660,7 @@ config DRM_PANEL_XINPENG_XPP055C272
 
 config DRM_PANEL_HIMAX_HX8399C_FHDPLUS
 	tristate "Himax HX8399C_FHDPLUS panel driver"
-	depends on OF
-	depends on DRM_MIPI_DSI
-	depends on BACKLIGHT_CLASS_DEVICE
+	select DRM_PANEL_MIPI_DSI_COMMON
 	help
 	  Say Y here if you want to enable support for the Himax
 	  HX8399C controller for 1080x1920/2280 LCD panels (found on Xiaomi Mi A2 Lite).


### PR DESCRIPTION
The SD card detection gpio level was inverted so it failed to boot from it.
Also there was a missing dependency with panel-dsi-common in the panel driver Kconfig.

The other commits add a battery node, gyro/accel sensor based on i2c-gpio and the flash led.
Both the battery and flash led commits have some kind of 'soft' dependency on #25 and #26.