### PR TITLE
SD Card and touch screen fixes for potter on 5.16

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-motorola-potter.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-motorola-potter.dts
@@ -268,7 +268,7 @@
 	pinctrl-0 = <&sdc2_clk_on &sdc2_cmd_on &sdc2_data_on &sdc2_cd_off>;
 	pinctrl-1 = <&sdc2_clk_off &sdc2_cmd_off &sdc2_data_off &sdc2_cd_off>;
 
-	cd-gpios = <&tlmm 133 GPIO_ACTIVE_LOW>;
+	//cd-gpios = <&tlmm 133 GPIO_ACTIVE_LOW>;
 };
 
 &smd_rpm_regulators {

--- a/arch/arm64/boot/dts/qcom/msm8953-motorola-potter.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-motorola-potter.dts
@@ -409,6 +409,7 @@
 		function = "gpio";
 		drive-strength = <2>;
 		bias-pull-up;
+		output-high;
 	};
 
 	pmx_mdss_default: pmx-mdss-default-pins {


### PR DESCRIPTION
CD-gpios don't work on potter for whatever reason, so the current solution is to just drop them. Also the touchscreen doesn't work, because the fixed regulator was disabled. @vladly says its better to model this as a reset-gpio in the synaptics driver, but I haven't had the time to do that, so I think its best to simply force the gpio to the on state for now.

