### PR TITLE
Revert "media: qcom: venus: use 4xx core get/put/power ops for 3xx"

### DIFF
--- a/drivers/media/platform/qcom/venus/pm_helpers.c
+++ b/drivers/media/platform/qcom/venus/pm_helpers.c
@@ -22,9 +22,6 @@
 #include "hfi_platform.h"
 
 static bool legacy_binding;
-static int core_get_v4(struct venus_core *core);
-static void core_put_v4(struct venus_core *core);
-static int core_power_v4(struct venus_core *core, int on);
 
 static int core_clks_get(struct venus_core *core)
 {
@@ -400,10 +397,12 @@ static int venc_power_v3(struct device *dev, int on)
 }
 
 static const struct venus_pm_ops pm_ops_v3 = {
-	.core_get = core_get_v4,
-	.core_put = core_put_v4,
-	.core_power = core_power_v4,
+	.core_get = core_get_v1,
+	.core_put = core_put_v1,
+	.core_power = core_power_v1,
+	.vdec_get = vdec_get_v3,
 	.vdec_power = vdec_power_v3,
+	.venc_get = venc_get_v3,
 	.venc_power = venc_power_v3,
 	.load_scale = load_scale_v1,
 };


### PR DESCRIPTION
This reverts commit 863b60f68fab373247ad338512acffe2172e6386.

and avoid this warning message
```
  CC      drivers/usb/gadget/function/f_eem.o
drivers/media/platform/qcom/venus/pm_helpers.c:377:12: warning: 'venc_get_v3' defined but not used [-Wunused-function]
  377 | static int venc_get_v3(struct device *dev)
      |            ^~~~~~~~~~~
drivers/media/platform/qcom/venus/pm_helpers.c:352:12: warning: 'vdec_get_v3' defined but not used [-Wunused-function]
  352 | static int vdec_get_v3(struct device *dev)
      |            ^~~~~~~~~~~
```