### PR TITLE
arm64: dts: qcom: msm8953: typo fix for modem pll supply

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-motorola-potter.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-motorola-potter.dts
@@ -268,7 +268,7 @@
 	status = "okay";
 
 	mss-supply = <&pm8953_s1>;
-	pll-suplly = <&pm8953_l7>;
+	pll-supply = <&pm8953_l7>;
 };
 
 &pm8953_resin {

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
@@ -310,7 +310,7 @@
 	status = "okay";
 
 	mss-supply = <&pm8953_s1>;
-	pll-suplly = <&pm8953_l7>;
+	pll-supply = <&pm8953_l7>;
 };
 
 &pm8953_resin {

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
@@ -302,7 +302,7 @@
 	status = "okay";
 
 	mss-supply = <&pm8953_s1>;
-	pll-suplly = <&pm8953_l7>;
+	pll-supply = <&pm8953_l7>;
 };
 
 &pmi8950_fg {

--- a/arch/arm64/boot/dts/qcom/sdm450-samsung-a6plte-r4.dts
+++ b/arch/arm64/boot/dts/qcom/sdm450-samsung-a6plte-r4.dts
@@ -697,7 +697,7 @@
 	status = "okay";
 
 	mss-supply = <&pm8953_s1>;
-	pll-suplly = <&pm8953_l7>;
+	pll-supply = <&pm8953_l7>;
 };
 
 &pm8953_resin {

--- a/arch/arm64/boot/dts/qcom/sdm632-fairphone-fp3.dts
+++ b/arch/arm64/boot/dts/qcom/sdm632-fairphone-fp3.dts
@@ -99,7 +99,7 @@
 	power-domains = <&rpmpd MSM8953_VDDCX>, <&rpmpd MSM8953_VDDMX>, <&rpmpd MSM8953_VDDMD>;
 	power-domain-names = "cx", "mx", "mss";
 
-	pll-suplly = <&pm8953_l7>;
+	pll-supply = <&pm8953_l7>;
 };
 
 &pm8953_resin {

--- a/arch/arm64/boot/dts/qcom/sdm632-motorola-ocean.dts
+++ b/arch/arm64/boot/dts/qcom/sdm632-motorola-ocean.dts
@@ -194,7 +194,7 @@
 	power-domains = <&rpmpd MSM8953_VDDCX>, <&rpmpd MSM8953_VDDMX>, <&rpmpd MSM8953_VDDMD>;
 	power-domain-names = "cx", "mx", "mss";
 
-	pll-suplly = <&pm8953_l7>;
+	pll-supply = <&pm8953_l7>;
 };
 
 &pm8953_resin {


### PR DESCRIPTION
this will avoid the usage of dummy regulator for the modem remoteproc and avoid a warning message within the dmesg 