### PR TITLE
dts: qcom: sdm632: motorola-ocean: Add vdd supplies

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm632-motorola-ocean.dts
+++ b/arch/arm64/boot/dts/qcom/sdm632-motorola-ocean.dts
@@ -2,9 +2,8 @@
 
 /dts-v1/;
 
-#include "msm8953.dtsi"
-#include "pm8953.dtsi"
 #include "sdm632.dtsi"
+#include "pm8953.dtsi"
 
 #include <dt-bindings/leds/common.h>
 
@@ -85,6 +84,13 @@
 			pmsg-size = <0x40000>;
 			record-size = <0x3f800>;
 		};
+	};
+
+	vph_pwr: vph-pwr-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vph_pwr";
+		regulator-always-on;
+		regulator-boot-on;
 	};
 };
 
@@ -217,8 +223,14 @@
 
 &rpm_requests {
 	pm8953-regulators {
-		// TODO Add supplies
+		compatible = "qcom,rpm-pm8953-regulators";
 
+		vdd_l1-supply = <&pm8953_s3>;
+		vdd_l2_l3-supply = <&pm8953_s3>;
+		vdd_l4_l5_l6_l7_l16_l19-supply = <&pm8953_s4>;
+		vdd_l8_l11_l12_l13_l14_l15-supply = <&vph_pwr>;
+		vdd_l9_l10_l17_l18_l22-supply = <&vph_pwr>;
+		
 		pm8953_s3: s3 {
 			regulator-min-microvolt = <984000>;
 			regulator-max-microvolt = <1240000>;


### PR DESCRIPTION
In order for ocean to correctly boot, it needs this vdd supplies. Title says it all, basically :P
