### PR TITLE
display: Add display support for hx8399c display for Redmi 6 Pro (PR Coming soon for new device)

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
@@ -357,3 +357,184 @@
 &usb3_dwc3 {
 	dr_mode = "peripheral";
 };
+
+&mdss_mdp {
+	dsi_truly_hx8399_1080_vid: qcom,mdss_dsi_truly_hx8399_1080p_video {
+		qcom,mdss-dsi-panel-name = "truly HX8399 1080p video mode dsi panel";
+		qcom,mdss-dsi-panel-type = "dsi_video_mode";
+		qcom,cont-splash-enabled;
+		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-virtual-channel-id = <0>;
+		qcom,mdss-dsi-stream = <0>;
+		qcom,mdss-dsi-panel-width = <1080>;
+		qcom,mdss-dsi-panel-height = <1920>;
+		qcom,mdss-dsi-h-front-porch = <90>;
+		qcom,mdss-dsi-h-back-porch = <60>;
+		qcom,mdss-dsi-h-pulse-width = <20>;
+		qcom,mdss-dsi-h-sync-skew = <0>;
+		qcom,mdss-dsi-v-front-porch = <9>;
+		qcom,mdss-dsi-v-back-porch = <3>;
+		qcom,mdss-dsi-v-pulse-width = <4>;
+		qcom,mdss-dsi-h-left-border = <0>;
+		qcom,mdss-dsi-h-right-border = <0>;
+		qcom,mdss-dsi-v-top-border = <0>;
+		qcom,mdss-dsi-v-bottom-border = <0>;
+		qcom,mdss-dsi-bpp = <24>;
+		qcom,mdss-dsi-underflow-color = <0xff>;
+		qcom,mdss-dsi-border-color = <0>;
+		qcom,mdss-dsi-h-sync-pulse = <0>;
+		qcom,mdss-dsi-traffic-mode = "burst_mode";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-panel-timings = [f9 3d 34 00 58 4d 36 3f 53 03 04 00];
+		qcom,mdss-dsi-t-clk-post = <0x02>;
+		qcom,mdss-dsi-t-clk-pre = <0x2d>;
+		qcom,mdss-dsi-bl-min-level = <160>;
+		qcom,mdss-dsi-bl-max-level = <3562>;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+                qcom,mdss-pan-physical-width-dimension = <69>;
+                qcom,mdss-pan-physical-height-dimension = <122>;
+		qcom,mdss-dsi-on-command = [
+			39 01 00 00 00 00 04
+			B9 FF 83 99
+			39 01 00 00 00 00 10
+			B1 00 04 6C 8C 01 32
+			22 11 11 58 62 56 73
+			02 02
+			39 01 00 00 00 00 0c
+			B2 00 80 80 AE 05 07
+			5A 11 10 10 00
+			39 01 00 00 00 00 2d
+			B4 00 ff 00 A0 00 A0
+			00 00 08 00 00 02 00
+			24 02 04 0C 33 06 00
+			00 00 a2 88 00 A0 00
+			A0 00 00 08 00 00 02
+			00 24 02 04 0C 00 00
+			00 a2 08
+			39 01 00 00 00 00 22
+			D3 00 00 00 00 00 00
+			06 00 32 10 05 00 05
+			00 00 00 00 00 00 00
+			00 00 00 01 00 05 05
+			03 00 00 00 05 40
+			39 01 00 00 00 00 21
+			D5 18 18 00 00 00 00
+			00 00 19 19 18 18 00
+			00 00 00 00 00 00 00
+			01 00 03 02 20 21 2F
+			2F 30 30 31 31
+			39 01 00 00 00 00 21
+			D6 18 18 40 40 40 40
+			40 40 18 18 19 19 40
+			40 40 40 40 40 40 40
+			02 03 00 01 21 20 2F
+			2F 30 30 31 31
+			39 01 00 00 00 00 11
+			D8 00 00 00 00 00 00
+			00 00 00 00 00 00 00
+			00 00 00
+			39 01 00 00 00 00 02
+			BD 01
+			39 01 00 00 00 00 11
+			D8 00 00 00 00 00 00
+			00 00 00 00 00 00 00
+			00 00 00
+			39 01 00 00 00 00 02
+			BD 02
+			39 01 00 00 00 00 09
+			D8 c0 00 0a 3f c0 00
+			0a 3f
+			39 01 00 00 00 00 02
+			BD 00
+			39 01 00 00 00 00 37
+			E0 01 14 20 19 3C 44
+			52 4F 57 61 69 6E 75
+			7B 83 85 89 90 92 97
+			8B 98 9B 51 4E 59 65
+			01 14 20 19 3C 44 52
+			4F 57 61 69 6F 75 7C
+			83 86 8A 91 92 98 8B
+			98 9C 51 4E 5A 65
+			39 01 00 00 00 00 02
+			BD 00
+			39 01 00 00 00 00 2C
+			C1 01 00 08 10 18 20
+			27 2F 37 3F 47 4F 56
+			5F 67 6E 76 7E 86 8E
+			96 9E A6 AF B6 BE C6
+			CD D6 DE E7 EF F8 FF
+			15 87 86 0F A9 11 0E
+			12 C0
+			39 01 00 00 00 00 02
+			BD 01
+			39 01 00 00 00 00 2B
+			C1 00 08 10 18 20 27
+			2F 38 3F 47 4F 57 5F
+			67 6F 77 7F 87 90 98
+			9F A7 AF B7 BE C7 CE
+			D6 DE E7 EF F7 FF 05
+			58 AA BA B0 94 CE C7
+			C0
+			39 01 00 00 00 00 02
+			BD 02
+			39 01 00 00 00 00 2B
+			C1 00 08 0F 17 1F 27
+			30 39 41 49 52 5A 62
+			6B 73 7B 83 8C 93 9B
+			A3 AB B3 BB C3 CB D3
+			DA E2 EA F2 F9 FF 0F
+			E6 71 D9 4E ED 82 82
+			C0
+			39 01 00 00 00 00 02
+			BD 00
+			39 01 00 00 00 00 02
+			CC 08
+			39 01 00 00 00 00 02
+			D2 22
+			39 01 00 00 00 00 04
+			C9 03 00 0A
+			39 01 00 00 00 00 03
+			51 00 00
+			15 01 00 00 00 00 02
+			53 24
+			15 01 00 00 0a 00 02
+			55 00
+			05 01 00 00 00 00 02
+			34 00
+			05 01 00 00 78 00 02
+			11 00
+			39 01 00 00 00 00 02
+			D0 39
+			05 01 00 00 00 00 02
+			29 00
+		];
+		qcom,mdss-dsi-off-command = [
+			05 01 00 00 32 00 02
+			28 00
+			05 01 00 00 64 00 02
+			10 00
+			39 01 00 00 00 00 04
+			B9 ff 83 99
+			39 01 00 00 00 00 02
+			b1 01
+		];
+		qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+		qcom,mdss-dsi-off-command-state = "dsi_lp_mode";
+		qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_dcs";
+		qcom,mdss-dsi-reset-sequence = <1 20>, <0 10>, <1 20>;
+		qcom,mdss-dsi-tx-eot-append;
+		qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+		qcom,mdss-dsi-panel-status-command = [06 01 00 01 05 00 02 D0 08];
+		qcom,mdss-dsi-panel-status-command-state = "dsi_hs_mode";
+		qcom,mdss-dsi-panel-status-check-mode = "reg_read_hx8399";
+		qcom,mdss-dsi-panel-status-value = <0x39 0xc7 0x7b>;
+		qcom,mdss-dsi-panel-status-read-length = <3>;
+		qcom,esd-check-enabled;
+	};
+};


### PR DESCRIPTION
This commit adds support to the hx8399c display used in the Redmi 6 Pro (PR Coming Soon for new device).