### PR TITLE
arm64: dts: qcom: msm8953-xiaomi-vince: add BMI120 alternative accele…

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
@@ -76,6 +76,18 @@
 			vdd-supply = <&pm8953_l10>;
 		};
 
+		imu@68 {
+			compatible = "bosch,bmi120";
+			reg = <0x68>;
+
+			vdd-supply = <&pm8953_l10>;
+			vddio-supply = <&pm8953_l6>;
+
+			mount-matrix = "0", "-1", "0",
+					"-1", "0", "0",
+					"0", "0", "1";
+		};
+
 		imu@6a {
 			compatible = "st,lsm6dsl";
 			reg = <0x6a>;


### PR DESCRIPTION
…rometer

This commit enable Bosch BMI120 accelerometer found on some xiaomi-vince variants.