### PR TITLE
arm64: dts: qcom: msm8953-xiaomi-common: enable wcd_codec

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-common.dtsi
@@ -417,3 +417,17 @@
 	vbus-supply = <&otg_vbus>;
 	dr_mode = "otg";
 };
+
+&wcd_codec {
+	qcom,gnd-jack-type-normally-open;
+	qcom,hphl-jack-type-normally-open;
+	qcom,mbhc-vthreshold-high = <75 150 237 450 500>;
+	qcom,mbhc-vthreshold-low = <75 150 237 450 500>;
+	qcom,micbias1-ext-cap;
+
+	vdd-cdc-io-supply = <&pm8953_l5>;
+	vdd-cdc-tx-rx-cx-supply = <&pm8953_s4>;
+	vdd-micbias-supply = <&pm8953_l13>;
+
+	status = "okay";
+};


### PR DESCRIPTION
Currently the digital codec driver does not probe because it depends on wcd_codec, which was disabled on xiaomi devices.

This assumes all xiaomi devices have the same wiring for the audio