### PR TITLE
arm64: dts: qcom: msm8953: add missing SPI interfaces and ir-spi-led IrDA transmitter on some xiaomi devices

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-common.dtsi
@@ -24,6 +24,13 @@
 		};
 	};
 
+	irda_regulator: regulator-irda {
+		compatible = "regulator-fixed";
+		gpio = <&tlmm 73 GPIO_ACTIVE_HIGH>;
+		regulator-name = "irda_regulator";
+		enable-active-high;
+	};
+
 	vph_pwr: vph-pwr-regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "vph_pwr";
@@ -362,6 +369,7 @@
 
 	status = "okay";
 };
+
 &tlmm {
 	ts_int_active: ts-int-active-state {
 		pins = "gpio65";

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
@@ -142,6 +142,19 @@
 	};
 };
 
+&spi_6 {
+	status = "okay";
+
+	irled@0 {
+		compatible = "ir-spi-led";
+		reg = <0x0>;
+		spi-max-frequency = <5000000>;
+		power-supply = <&irda_regulator>;
+		duty-cycle = /bits/ 8 <60>;
+		led-active-low;
+	};
+};
+
 &tlmm {
 	gpio-reserved-ranges = <0 4>, <16 4>, <135 4>;
 

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-tissot.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-tissot.dts
@@ -174,6 +174,19 @@
 	cd-gpios = <&tlmm 133 GPIO_ACTIVE_HIGH>;
 };
 
+&spi_6 {
+	status = "okay";
+
+	irled@0 {
+		compatible = "ir-spi-led";
+		reg = <0x0>;
+		spi-max-frequency = <5000000>;
+		power-supply = <&irda_regulator>;
+		duty-cycle = /bits/ 8 <60>;
+		led-active-low;
+	};
+};
+
 &sound_card {
 	status = "okay";
 

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
@@ -144,6 +144,19 @@
 	status = "okay";
 };
 
+&spi_6 {
+	status = "okay";
+
+	irled@0 {
+		compatible = "ir-spi-led";
+		reg = <0x0>;
+		spi-max-frequency = <5000000>;
+		power-supply = <&irda_regulator>;
+		duty-cycle = /bits/ 8 <60>;
+		led-active-low;
+	};
+};
+
 &tlmm {
 	gpio-reserved-ranges = <0 4>, <16 4>, <135 4>;
 

--- a/arch/arm64/boot/dts/qcom/msm8953.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8953.dtsi
@@ -1098,6 +1098,34 @@
 				bias-disable;
 			};
 
+			spi_3_default: spi-3-default-state {
+				pins = "gpio10", "gpio11";
+				function = "blsp_spi3";
+				drive-strength = <2>;
+				bias-disable;
+			};
+
+			spi_3_sleep: spi-3-sleep-state {
+				pins = "gpio10", "gpio11";
+				function = "gpio";
+				drive-strength = <2>;
+				bias-disable;
+			};
+
+			spi_6_default: spi-6-default-state {
+				pins = "gpio22", "gpio23";
+				function = "blsp_spi6";
+				drive-strength = <2>;
+				bias-disable;
+			};
+
+			spi_6_sleep: spi-6-sleep-state {
+				pins = "gpio22", "gpio23";
+				function = "gpio";
+				drive-strength = <2>;
+				bias-disable;
+			};
+
 			/* Active configuration of bus pins */
 			wcnss_default: wcnss-default-pins {
 				wcss_wlan2 {
@@ -2247,6 +2275,23 @@
 			status = "disabled";
 		};
 
+		spi_3: spi@78b7000 {
+			compatible = "qcom,spi-qup-v2.2.1";
+			reg = <0x78b7000 0x600>;
+			interrupts = <GIC_SPI 97 IRQ_TYPE_LEVEL_HIGH>;
+			clock-names = "core", "iface";
+			clocks = <&gcc GCC_BLSP1_QUP3_I2C_APPS_CLK>,
+				 <&gcc GCC_BLSP1_AHB_CLK>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-0 = <&spi_3_default>;
+			pinctrl-1 = <&spi_3_sleep>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "disabled";
+		};
+
 		i2c_4: i2c@78b8000 {
 			compatible = "qcom,i2c-qup-v2.2.1";
 			reg = <0x78b8000 0x600>;
@@ -2291,6 +2336,23 @@
 			pinctrl-names = "default", "sleep";
 			pinctrl-0 = <&i2c_6_default>;
 			pinctrl-1 = <&i2c_6_sleep>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "disabled";
+		};
+
+		spi_6: spi@7af6000 {
+			compatible = "qcom,spi-qup-v2.2.1";
+			reg = <0x7af6000 0x600>;
+			interrupts = <GIC_SPI 300 IRQ_TYPE_LEVEL_HIGH>;
+			clock-names = "core", "iface";
+			clocks = <&gcc GCC_BLSP2_QUP2_I2C_APPS_CLK>,
+				 <&gcc GCC_BLSP2_AHB_CLK>;
+			pinctrl-names = "default", "sleep";
+			pinctrl-0 = <&spi_6_default>;
+			pinctrl-1 = <&spi_6_sleep>;
 
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
On downstream device-tree the vendor is Peel Technologies (module named peelir).

https://github.com/GhostMaster69-dev/android_kernel_xiaomi_vince/blob/f38ebd5d711ea84d727f247aebab2328a98f94cd/arch/arm64/boot/dts/qcom/vince/vince-general.dtsi#LL58C1-L58C1

https://github.com/GhostMaster69-dev/android_kernel_xiaomi_vince/blob/master/arch/arm64/boot/dts/qcom/vince/vince-qrd.dtsi#L479

seems to present on sakura, daisy, vince and tissot (look for peel_ir in downstream)

need to set  `CONFIG_IR_SPI=m` and `CONFIG_SPI_QUP=m`