### PR TITLE
arm64: dts: qcom: sdm632: motorola-ocean: Add brightness levels

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm632-motorola-ocean.dts
+++ b/arch/arm64/boot/dts/qcom/sdm632-motorola-ocean.dts
@@ -21,6 +21,7 @@
 
 	backlight: backlight {
 		compatible = "led-backlight";
+		default-brightness-level = <150>;
 		leds = <&led>;
 	};
 


### PR DESCRIPTION
This assigns 16 levels of brightness for backlight, and sets level 9 as default. In my rather crude test of using phosh's brightness slider, it seemed visually the same as without the levels. 