### PR TITLE
IPA v2 for 6.3.0/ipa

### DIFF
--- a/drivers/dma/qcom/bam_dma.c
+++ b/drivers/dma/qcom/bam_dma.c
@@ -58,6 +58,7 @@ struct bam_desc_hw {
 #define DESC_FLAG_EOB BIT(13)
 #define DESC_FLAG_NWD BIT(12)
 #define DESC_FLAG_CMD BIT(11)
+#define DESC_FLAG_IMM BIT(8)
 
 struct bam_async_desc {
 	struct virt_dma_desc vd;
@@ -693,6 +694,8 @@ static struct dma_async_tx_descriptor *bam_prep_slave_sg(struct dma_chan *chan,
 		do {
 			if (flags & DMA_PREP_CMD)
 				desc->flags |= cpu_to_le16(DESC_FLAG_CMD);
+			else if (flags & DMA_PREP_IMM_CMD)
+				desc->flags |= cpu_to_le16(DESC_FLAG_IMM);
 
 			desc->addr = cpu_to_le32(sg_dma_address(sg) +
 						 curr_offset);

--- a/drivers/net/ipa/data/ipa_data-v3.1.c
+++ b/drivers/net/ipa/data/ipa_data-v3.1.c
@@ -65,7 +65,7 @@ static const struct ipa_qsb_data ipa_qsb_data[] = {
 /* Endpoint data for an SoC having IPA v3.1 */
 static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 	[IPA_ENDPOINT_AP_COMMAND_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 6,
 		.endpoint_id	= 22,
 		.toward_ipa	= true,
@@ -86,7 +86,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_LAN_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 7,
 		.endpoint_id	= 15,
 		.toward_ipa	= false,
@@ -109,7 +109,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 5,
 		.endpoint_id	= 3,
 		.toward_ipa	= true,
@@ -134,7 +134,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 8,
 		.endpoint_id	= 16,
 		.toward_ipa	= false,
@@ -158,7 +158,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_LAN_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 4,
 		.endpoint_id	= 9,
 		.toward_ipa	= true,
@@ -167,7 +167,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 0,
 		.endpoint_id	= 5,
 		.toward_ipa	= true,
@@ -176,7 +176,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_RX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 5,
 		.endpoint_id	= 18,
 		.toward_ipa	= false,

--- a/drivers/net/ipa/data/ipa_data-v3.5.1.c
+++ b/drivers/net/ipa/data/ipa_data-v3.5.1.c
@@ -56,7 +56,7 @@ static const struct ipa_qsb_data ipa_qsb_data[] = {
 /* Endpoint datdata for an SoC having IPA v3.5.1 */
 static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 	[IPA_ENDPOINT_AP_COMMAND_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 4,
 		.endpoint_id	= 5,
 		.toward_ipa	= true,
@@ -77,7 +77,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_LAN_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 5,
 		.endpoint_id	= 9,
 		.toward_ipa	= false,
@@ -100,7 +100,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 3,
 		.endpoint_id	= 2,
 		.toward_ipa	= true,
@@ -126,7 +126,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 6,
 		.endpoint_id	= 10,
 		.toward_ipa	= false,
@@ -150,7 +150,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_LAN_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 0,
 		.endpoint_id	= 3,
 		.toward_ipa	= true,
@@ -159,7 +159,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 4,
 		.endpoint_id	= 6,
 		.toward_ipa	= true,
@@ -168,7 +168,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_RX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 2,
 		.endpoint_id	= 12,
 		.toward_ipa	= false,

--- a/drivers/net/ipa/data/ipa_data-v4.11.c
+++ b/drivers/net/ipa/data/ipa_data-v4.11.c
@@ -50,7 +50,7 @@ static const struct ipa_qsb_data ipa_qsb_data[] = {
 /* Endpoint configuration data for an SoC having IPA v4.11 */
 static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 	[IPA_ENDPOINT_AP_COMMAND_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 5,
 		.endpoint_id	= 7,
 		.toward_ipa	= true,
@@ -71,7 +71,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_LAN_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 14,
 		.endpoint_id	= 9,
 		.toward_ipa	= false,
@@ -94,7 +94,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 2,
 		.endpoint_id	= 2,
 		.toward_ipa	= true,
@@ -119,7 +119,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 7,
 		.endpoint_id	= 16,
 		.toward_ipa	= false,
@@ -143,7 +143,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 0,
 		.endpoint_id	= 5,
 		.toward_ipa	= true,
@@ -152,13 +152,13 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_RX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 7,
 		.endpoint_id	= 14,
 		.toward_ipa	= false,
 	},
 	[IPA_ENDPOINT_MODEM_DL_NLO_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 2,
 		.endpoint_id	= 8,
 		.toward_ipa	= true,

--- a/drivers/net/ipa/data/ipa_data-v4.2.c
+++ b/drivers/net/ipa/data/ipa_data-v4.2.c
@@ -46,7 +46,7 @@ static const struct ipa_qsb_data ipa_qsb_data[] = {
 /* Endpoint configuration data for an SoC having IPA v4.2 */
 static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 	[IPA_ENDPOINT_AP_COMMAND_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 1,
 		.endpoint_id	= 6,
 		.toward_ipa	= true,
@@ -67,7 +67,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_LAN_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 2,
 		.endpoint_id	= 8,
 		.toward_ipa	= false,
@@ -90,7 +90,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 0,
 		.endpoint_id	= 1,
 		.toward_ipa	= true,
@@ -116,7 +116,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 3,
 		.endpoint_id	= 9,
 		.toward_ipa	= false,
@@ -140,19 +140,19 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_COMMAND_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 1,
 		.endpoint_id	= 5,
 		.toward_ipa	= true,
 	},
 	[IPA_ENDPOINT_MODEM_LAN_RX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 3,
 		.endpoint_id	= 11,
 		.toward_ipa	= false,
 	},
 	[IPA_ENDPOINT_MODEM_AP_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 0,
 		.endpoint_id	= 4,
 		.toward_ipa	= true,
@@ -161,7 +161,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_RX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 2,
 		.endpoint_id	= 10,
 		.toward_ipa	= false,

--- a/drivers/net/ipa/data/ipa_data-v4.5.c
+++ b/drivers/net/ipa/data/ipa_data-v4.5.c
@@ -59,7 +59,7 @@ static const struct ipa_qsb_data ipa_qsb_data[] = {
 /* Endpoint configuration data for an SoC having IPA v4.5 */
 static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 	[IPA_ENDPOINT_AP_COMMAND_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 9,
 		.endpoint_id	= 7,
 		.toward_ipa	= true,
@@ -80,7 +80,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_LAN_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 10,
 		.endpoint_id	= 16,
 		.toward_ipa	= false,
@@ -103,7 +103,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 7,
 		.endpoint_id	= 2,
 		.toward_ipa	= true,
@@ -128,7 +128,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 1,
 		.endpoint_id	= 14,
 		.toward_ipa	= false,
@@ -152,7 +152,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 0,
 		.endpoint_id	= 5,
 		.toward_ipa	= true,
@@ -161,13 +161,13 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_RX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 7,
 		.endpoint_id	= 21,
 		.toward_ipa	= false,
 	},
 	[IPA_ENDPOINT_MODEM_DL_NLO_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 2,
 		.endpoint_id	= 8,
 		.toward_ipa	= true,

--- a/drivers/net/ipa/data/ipa_data-v4.7.c
+++ b/drivers/net/ipa/data/ipa_data-v4.7.c
@@ -48,7 +48,7 @@ static const struct ipa_qsb_data ipa_qsb_data[] = {
 /* Endpoint configuration data for an SoC having IPA v4.7 */
 static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 	[IPA_ENDPOINT_AP_COMMAND_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 5,
 		.endpoint_id	= 7,
 		.toward_ipa	= true,
@@ -69,7 +69,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_LAN_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 14,
 		.endpoint_id	= 9,
 		.toward_ipa	= false,
@@ -92,7 +92,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 2,
 		.endpoint_id	= 2,
 		.toward_ipa	= true,
@@ -116,7 +116,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 7,
 		.endpoint_id	= 16,
 		.toward_ipa	= false,
@@ -139,7 +139,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 0,
 		.endpoint_id	= 5,
 		.toward_ipa	= true,
@@ -148,13 +148,13 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_RX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 7,
 		.endpoint_id	= 14,
 		.toward_ipa	= false,
 	},
 	[IPA_ENDPOINT_MODEM_DL_NLO_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 2,
 		.endpoint_id	= 8,
 		.toward_ipa	= true,

--- a/drivers/net/ipa/data/ipa_data-v4.9.c
+++ b/drivers/net/ipa/data/ipa_data-v4.9.c
@@ -51,7 +51,7 @@ static const struct ipa_qsb_data ipa_qsb_data[] = {
 /* Endpoint configuration data for an SoC having IPA v4.9 */
 static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 	[IPA_ENDPOINT_AP_COMMAND_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 6,
 		.endpoint_id	= 7,
 		.toward_ipa	= true,
@@ -72,7 +72,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_LAN_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 7,
 		.endpoint_id	= 11,
 		.toward_ipa	= false,
@@ -95,7 +95,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_TX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 2,
 		.endpoint_id	= 2,
 		.toward_ipa	= true,
@@ -120,7 +120,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_AP_MODEM_RX] = {
-		.ee_id		= GSI_EE_AP,
+		.ee_id		= DMA_EE_AP,
 		.channel_id	= 12,
 		.endpoint_id	= 20,
 		.toward_ipa	= false,
@@ -144,7 +144,7 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 0,
 		.endpoint_id	= 5,
 		.toward_ipa	= true,
@@ -153,13 +153,13 @@ static const struct ipa_gsi_endpoint_data ipa_gsi_endpoint_data[] = {
 		},
 	},
 	[IPA_ENDPOINT_MODEM_AP_RX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 7,
 		.endpoint_id	= 16,
 		.toward_ipa	= false,
 	},
 	[IPA_ENDPOINT_MODEM_DL_NLO_TX] = {
-		.ee_id		= GSI_EE_MODEM,
+		.ee_id		= DMA_EE_MODEM,
 		.channel_id	= 2,
 		.endpoint_id	= 8,
 		.toward_ipa	= true,

--- a/drivers/net/ipa/gsi.c
+++ b/drivers/net/ipa/gsi.c
@@ -725,7 +725,7 @@ static void gsi_evt_ring_program(struct gsi *gsi, u32 evt_ring_id)
 	reg = gsi_reg(gsi, EV_CH_E_CNTXT_0);
 	/* We program all event rings as GPI type/protocol */
 	val = reg_encode(reg, EV_CHTYPE, GSI_CHANNEL_TYPE_GPI);
-	/* EV_EE field is 0 (GSI_EE_AP) */
+	/* EV_EE field is 0 (DMA_EE_AP) */
 	val |= reg_bit(reg, EV_INTYPE);
 	val |= reg_encode(reg, EV_ELEMENT_SIZE, GSI_RING_ELEMENT_SIZE);
 	iowrite32(val, gsi->virt + reg_n_offset(reg, evt_ring_id));
@@ -1799,7 +1799,7 @@ static int gsi_generic_command(struct gsi *gsi, u32 channel_id,
 	reg = gsi_reg(gsi, GENERIC_CMD);
 	val = reg_encode(reg, GENERIC_OPCODE, opcode);
 	val |= reg_encode(reg, GENERIC_CHID, channel_id);
-	val |= reg_encode(reg, GENERIC_EE, GSI_EE_MODEM);
+	val |= reg_encode(reg, GENERIC_EE, DMA_EE_MODEM);
 	if (gsi->version >= IPA_VERSION_4_11)
 		val |= reg_encode(reg, GENERIC_PARAMS, params);
 
@@ -2162,7 +2162,7 @@ static bool gsi_channel_data_valid(struct gsi *gsi, bool command,
 		return false;
 	}
 
-	if (data->ee_id != GSI_EE_AP && data->ee_id != GSI_EE_MODEM) {
+	if (data->ee_id != DMA_EE_AP && data->ee_id != DMA_EE_MODEM) {
 		dev_err(dev, "bad EE id %u; not AP or modem\n", data->ee_id);
 		return false;
 	}
@@ -2315,7 +2315,7 @@ static int gsi_channel_init(struct gsi *gsi, u32 count,
 			continue;	/* Skip over empty slots */
 
 		/* Mark modem channels to be allocated (hardware workaround) */
-		if (data[i].ee_id == GSI_EE_MODEM) {
+		if (data[i].ee_id == DMA_EE_MODEM) {
 			if (modem_alloc)
 				gsi->modem_channel_bitmap |=
 						BIT(data[i].channel_id);
@@ -2333,7 +2333,7 @@ err_unwind:
 	while (i--) {
 		if (ipa_gsi_endpoint_data_empty(&data[i]))
 			continue;
-		if (modem_alloc && data[i].ee_id == GSI_EE_MODEM) {
+		if (modem_alloc && data[i].ee_id == DMA_EE_MODEM) {
 			gsi->modem_channel_bitmap &= ~BIT(data[i].channel_id);
 			continue;
 		}

--- a/drivers/net/ipa/gsi_reg.h
+++ b/drivers/net/ipa/gsi_reg.h
@@ -31,7 +31,7 @@ struct gsi;
  *
  * The offset of a register dependent on execution environment is computed
  * by a macro that is supplied a parameter "ee".  The "ee" value is a member
- * of the gsi_ee_id enumerated type.
+ * of the dma_ee_id enumerated type.
  *
  * The offset of a channel register is computed by a macro that is supplied a
  * parameter "ch".  The "ch" value is a channel id whose maximum value is 30
@@ -155,7 +155,7 @@ enum gsi_prefetch_mode {
 /* EV_CH_E_CNTXT_0 register */
 enum gsi_reg_ch_c_ev_ch_e_cntxt_0_field_id {
 	EV_CHTYPE,	/* enum gsi_channel_type */
-	EV_EE,		/* enum gsi_ee_id; always GSI_EE_AP for us */
+	EV_EE,		/* enum dma_ee_id; always DMA_EE_AP for us */
 	EV_EVCHID,
 	EV_INTYPE,
 	EV_CHSTATE,

--- a/drivers/net/ipa/ipa_data.h
+++ b/drivers/net/ipa/ipa_data.h
@@ -124,7 +124,7 @@ struct ipa_endpoint_data {
  * @endpoint:	IPA endpoint configuration data (see above)
  */
 struct ipa_gsi_endpoint_data {
-	u8 ee_id;		/* enum gsi_ee_id */
+	u8 ee_id;		/* enum dma_ee_id */
 	u8 channel_id;
 	u8 endpoint_id;
 	bool toward_ipa;

--- a/drivers/net/ipa/ipa_endpoint.c
+++ b/drivers/net/ipa/ipa_endpoint.c
@@ -254,7 +254,7 @@ static bool ipa_endpoint_data_valid_one(struct ipa *ipa, u32 count,
 		}
 
 		/* Nothing more to check for non-AP RX */
-		if (data->ee_id != GSI_EE_AP)
+		if (data->ee_id != DMA_EE_AP)
 			return true;
 
 		rx_config = &data->endpoint.config.rx;
@@ -351,7 +351,7 @@ static bool ipa_endpoint_data_valid_one(struct ipa *ipa, u32 count,
 		}
 
 		/* ...and if it's to be an AP endpoint... */
-		if (other_data->ee_id == GSI_EE_AP) {
+		if (other_data->ee_id == DMA_EE_AP) {
 			/* ...make sure it has status enabled. */
 			if (!other_data->endpoint.config.status_enable) {
 				dev_err(dev,
@@ -579,7 +579,7 @@ void ipa_endpoint_modem_pause_all(struct ipa *ipa, bool enable)
 	while (endpoint_id < ipa->endpoint_count) {
 		struct ipa_endpoint *endpoint = &ipa->endpoint[endpoint_id++];
 
-		if (endpoint->ee_id != GSI_EE_MODEM)
+		if (endpoint->ee_id != DMA_EE_MODEM)
 			continue;
 
 		if (!endpoint->toward_ipa)
@@ -618,7 +618,7 @@ int ipa_endpoint_modem_exception_reset_all(struct ipa *ipa)
 
 		/* We only reset modem TX endpoints */
 		endpoint = &ipa->endpoint[endpoint_id];
-		if (!(endpoint->ee_id == GSI_EE_MODEM && endpoint->toward_ipa))
+		if (!(endpoint->ee_id == DMA_EE_MODEM && endpoint->toward_ipa))
 			continue;
 
 		reg = ipa_reg(ipa, ENDP_STATUS);
@@ -1159,7 +1159,7 @@ void ipa_endpoint_modem_hol_block_clear_all(struct ipa *ipa)
 	while (endpoint_id < ipa->endpoint_count) {
 		struct ipa_endpoint *endpoint = &ipa->endpoint[endpoint_id++];
 
-		if (endpoint->toward_ipa || endpoint->ee_id != GSI_EE_MODEM)
+		if (endpoint->toward_ipa || endpoint->ee_id != DMA_EE_MODEM)
 			continue;
 
 		ipa_endpoint_init_hol_block_disable(endpoint);
@@ -1929,7 +1929,7 @@ static void ipa_endpoint_setup_one(struct ipa_endpoint *endpoint)
 	u32 channel_id = endpoint->channel_id;
 
 	/* Only AP endpoints get set up */
-	if (endpoint->ee_id != GSI_EE_AP)
+	if (endpoint->ee_id != DMA_EE_AP)
 		return;
 
 	endpoint->skb_frag_max = gsi->channel[channel_id].trans_tre_max - 1;
@@ -2093,7 +2093,7 @@ static void ipa_endpoint_init_one(struct ipa *ipa, enum ipa_endpoint_name name,
 
 	endpoint = &ipa->endpoint[data->endpoint_id];
 
-	if (data->ee_id == GSI_EE_AP)
+	if (data->ee_id == DMA_EE_AP)
 		ipa->channel_map[data->channel_id] = endpoint;
 	ipa->name_map[name] = endpoint;
 
@@ -2170,7 +2170,7 @@ int ipa_endpoint_init(struct ipa *ipa, u32 count,
 
 		if (data->endpoint.filter_support)
 			filtered |= BIT(data->endpoint_id);
-		if (data->ee_id == GSI_EE_MODEM && data->toward_ipa)
+		if (data->ee_id == DMA_EE_MODEM && data->toward_ipa)
 			ipa->modem_tx_count++;
 	}
 

--- a/drivers/net/ipa/ipa_endpoint.h
+++ b/drivers/net/ipa/ipa_endpoint.h
@@ -151,7 +151,7 @@ enum ipa_replenish_flag {
  */
 struct ipa_endpoint {
 	struct ipa *ipa;
-	enum gsi_ee_id ee_id;
+	enum dma_ee_id ee_id;
 	u32 channel_id;
 	u32 endpoint_id;
 	bool toward_ipa;

--- a/drivers/net/ipa/ipa_gsi.c
+++ b/drivers/net/ipa/ipa_gsi.c
@@ -51,5 +51,5 @@ void ipa_gsi_channel_tx_completed(struct gsi *gsi, u32 channel_id, u32 count,
 /* Indicate whether an endpoint config data entry is "empty" */
 bool ipa_gsi_endpoint_data_empty(const struct ipa_gsi_endpoint_data *data)
 {
-	return data->ee_id == GSI_EE_AP && !data->channel.tlv_count;
+	return data->ee_id == DMA_EE_AP && !data->channel.tlv_count;
 }

--- a/drivers/net/ipa/ipa_main.c
+++ b/drivers/net/ipa/ipa_main.c
@@ -704,7 +704,7 @@ static void ipa_validate_build(void)
 	BUILD_BUG_ON(!IS_ENABLED(CONFIG_64BIT) && sizeof(size_t) != 4);
 
 	/* Code assumes the EE ID for the AP is 0 (zeroed structure field) */
-	BUILD_BUG_ON(GSI_EE_AP != 0);
+	BUILD_BUG_ON(DMA_EE_AP != 0);
 
 	/* There's no point if we have no channels or event rings */
 	BUILD_BUG_ON(!GSI_CHANNEL_COUNT_MAX);

--- a/drivers/net/ipa/ipa_reg.h
+++ b/drivers/net/ipa/ipa_reg.h
@@ -29,7 +29,7 @@ struct ipa;
  * of registers is computed based on an "base" offset, plus an endpoint's
  * ID multiplied and a "stride" value for the register.  Similarly, some
  * registers have an offset that depends on execution environment.  In
- * this case, the stride is multiplied by a member of the gsi_ee_id
+ * this case, the stride is multiplied by a member of the dma_ee_id
  * enumerated type.
  *
  * Each version of IPA implements an array of ipa_reg structures indexed
@@ -99,7 +99,7 @@ enum ipa_reg_id {
 	ENDP_FILTER_ROUTER_HSH_CFG,			/* Not IPA v4.2 */
 	ENDP_FILTER_CACHE_CFG,				/* IPA v5.0+ */
 	ENDP_ROUTER_CACHE_CFG,				/* IPA v5.0+ */
-	/* The IRQ registers that follow are only used for GSI_EE_AP */
+	/* The IRQ registers that follow are only used for DMA_EE_AP */
 	IPA_IRQ_STTS,
 	IPA_IRQ_EN,
 	IPA_IRQ_CLR,

--- a/drivers/net/ipa/ipa_table.c
+++ b/drivers/net/ipa/ipa_table.c
@@ -232,7 +232,7 @@ ipa_filter_reset_table(struct ipa *ipa, bool hashed, bool ipv6, bool modem)
 {
 	u64 ep_mask = ipa->filtered;
 	struct gsi_trans *trans;
-	enum gsi_ee_id ee_id;
+	enum dma_ee_id ee_id;
 
 	trans = ipa_cmd_trans_alloc(ipa, hweight64(ep_mask));
 	if (!trans) {
@@ -242,7 +242,7 @@ ipa_filter_reset_table(struct ipa *ipa, bool hashed, bool ipv6, bool modem)
 		return -EBUSY;
 	}
 
-	ee_id = modem ? GSI_EE_MODEM : GSI_EE_AP;
+	ee_id = modem ? DMA_EE_MODEM : DMA_EE_AP;
 	while (ep_mask) {
 		u32 endpoint_id = __ffs(ep_mask);
 		struct ipa_endpoint *endpoint;
@@ -519,7 +519,7 @@ static void ipa_filter_tuple_zero(struct ipa_endpoint *endpoint)
 /* Configure a hashed filter table; there is no ipa_filter_deconfig() */
 static void ipa_filter_config(struct ipa *ipa, bool modem)
 {
-	enum gsi_ee_id ee_id = modem ? GSI_EE_MODEM : GSI_EE_AP;
+	enum dma_ee_id ee_id = modem ? DMA_EE_MODEM : DMA_EE_AP;
 	u64 ep_mask = ipa->filtered;
 
 	if (!ipa_table_hash_support(ipa))

--- a/drivers/net/ipa/ipa_version.h
+++ b/drivers/net/ipa/ipa_version.h
@@ -69,11 +69,11 @@ static inline bool ipa_version_supported(enum ipa_version version)
 }
 
 /* Execution environment IDs */
-enum gsi_ee_id {
-	GSI_EE_AP		= 0x0,
-	GSI_EE_MODEM		= 0x1,
-	GSI_EE_UC		= 0x2,
-	GSI_EE_TZ		= 0x3,
+enum dma_ee_id {
+	DMA_EE_AP		= 0x0,
+	DMA_EE_MODEM		= 0x1,
+	DMA_EE_UC		= 0x2,
+	DMA_EE_TZ		= 0x3,
 };
 
 #endif /* _IPA_VERSION_H_ */

--- a/drivers/net/ipa/ipa_version.h
+++ b/drivers/net/ipa/ipa_version.h
@@ -8,6 +8,9 @@
 
 /**
  * enum ipa_version
+ * @IPA_VERSION_2_0:	IPA version 2.0/BAM
+ * @IPA_VERSION_2_5:	IPA version 2.5/BAM
+ * @IPA_VERSION_2_6L:	IPA version 2.6 lite/BAM
  * @IPA_VERSION_3_0:	IPA version 3.0/GSI version 1.0
  * @IPA_VERSION_3_1:	IPA version 3.1/GSI version 1.0
  * @IPA_VERSION_3_5:	IPA version 3.5/GSI version 1.2
@@ -24,10 +27,13 @@
  * @IPA_VERSION_5_5:	IPA version 5.5/GSI version 5.5
  * @IPA_VERSION_COUNT:	Number of defined IPA versions
  *
- * Defines the version of IPA (and GSI) hardware present on the platform.
+ * Defines the version of IPA (and DMA) hardware present on the platform.
  * Please update ipa_version_string() whenever a new version is added.
  */
 enum ipa_version {
+	IPA_VERSION_2_0,
+	IPA_VERSION_2_5,
+	IPA_VERSION_2_6L,
 	IPA_VERSION_3_0,
 	IPA_VERSION_3_1,
 	IPA_VERSION_3_5,

--- a/drivers/net/ipa/reg/gsi_reg-v3.1.c
+++ b/drivers/net/ipa/reg/gsi_reg-v3.1.c
@@ -9,10 +9,10 @@
 #include "../gsi_reg.h"
 
 REG(INTER_EE_SRC_CH_IRQ_MSK, inter_ee_src_ch_irq_msk,
-    0x0000c020 + 0x1000 * GSI_EE_AP);
+    0x0000c020 + 0x1000 * DMA_EE_AP);
 
 REG(INTER_EE_SRC_EV_CH_IRQ_MSK, inter_ee_src_ev_ch_irq_msk,
-    0x0000c024 + 0x1000 * GSI_EE_AP);
+    0x0000c024 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ch_c_cntxt_0_fmask[] = {
 	[CHTYPE_PROTOCOL]				= GENMASK(2, 0),
@@ -27,7 +27,7 @@ static const u32 reg_ch_c_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_0, ch_c_cntxt_0,
-		  0x0001c000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001c000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_cntxt_1_fmask[] = {
 	[CH_R_LENGTH]					= GENMASK(15, 0),
@@ -35,11 +35,11 @@ static const u32 reg_ch_c_cntxt_1_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_1, ch_c_cntxt_1,
-		  0x0001c004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001c004 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0001c008 + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0001c008 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0001c00c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0001c00c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_qos_fmask[] = {
 	[WRR_WEIGHT]					= GENMASK(3, 0),
@@ -49,7 +49,7 @@ static const u32 reg_ch_c_qos_fmask[] = {
 						/* Bits 10-31 reserved */
 };
 
-REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0001c05c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0001c05c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_error_log_fmask[] = {
 	[ERR_ARG3]					= GENMASK(3, 0),
@@ -63,16 +63,16 @@ static const u32 reg_error_log_fmask[] = {
 };
 
 REG_STRIDE(CH_C_SCRATCH_0, ch_c_scratch_0,
-	   0x0001c060 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c060 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_1, ch_c_scratch_1,
-	   0x0001c064 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c064 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_2, ch_c_scratch_2,
-	   0x0001c068 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c068 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_3, ch_c_scratch_3,
-	   0x0001c06c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c06c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 	[EV_CHTYPE]					= GENMASK(3, 0),
@@ -85,23 +85,23 @@ static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_0, ev_ch_e_cntxt_0,
-		  0x0001d000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001d000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_1_fmask[] = {
 	[R_LENGTH]					= GENMASK(15, 0),
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_1, ev_ch_e_cntxt_1,
-		  0x0001d004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001d004 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_2, ev_ch_e_cntxt_2,
-	   0x0001d008 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d008 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_3, ev_ch_e_cntxt_3,
-	   0x0001d00c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d00c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_4, ev_ch_e_cntxt_4,
-	   0x0001d010 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d010 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 	[EV_MODT]					= GENMASK(15, 0),
@@ -110,41 +110,41 @@ static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_8, ev_ch_e_cntxt_8,
-		  0x0001d020 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001d020 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_9, ev_ch_e_cntxt_9,
-	   0x0001d024 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d024 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_10, ev_ch_e_cntxt_10,
-	   0x0001d028 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d028 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_11, ev_ch_e_cntxt_11,
-	   0x0001d02c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d02c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_12, ev_ch_e_cntxt_12,
-	   0x0001d030 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d030 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_13, ev_ch_e_cntxt_13,
-	   0x0001d034 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d034 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_0, ev_ch_e_scratch_0,
-	   0x0001d048 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d048 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_1, ev_ch_e_scratch_1,
-	   0x0001d04c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d04c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_DOORBELL_0, ch_c_doorbell_0,
-	   0x0001e000 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x0001e000 + 0x4000 * DMA_EE_AP, 0x08);
 
 REG_STRIDE(EV_CH_E_DOORBELL_0, ev_ch_e_doorbell_0,
-	   0x0001e100 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x0001e100 + 0x4000 * DMA_EE_AP, 0x08);
 
 static const u32 reg_gsi_status_fmask[] = {
 	[ENABLED]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(GSI_STATUS, gsi_status, 0x0001f000 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GSI_STATUS, gsi_status, 0x0001f000 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ch_cmd_fmask[] = {
 	[CH_CHID]					= GENMASK(7, 0),
@@ -152,7 +152,7 @@ static const u32 reg_ch_cmd_fmask[] = {
 	[CH_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(CH_CMD, ch_cmd, 0x0001f008 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CH_CMD, ch_cmd, 0x0001f008 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_CHID]					= GENMASK(7, 0),
@@ -160,7 +160,7 @@ static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x0001f010 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x0001f010 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_generic_cmd_fmask[] = {
 	[GENERIC_OPCODE]				= GENMASK(4, 0),
@@ -169,58 +169,58 @@ static const u32 reg_generic_cmd_fmask[] = {
 						/* Bits 14-31 reserved */
 };
 
-REG_FIELDS(GENERIC_CMD, generic_cmd, 0x0001f018 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GENERIC_CMD, generic_cmd, 0x0001f018 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x0001f080 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x0001f080 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x0001f088 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x0001f088 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x0001f090 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x0001f090 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x0001f094 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x0001f094 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_MSK, cntxt_src_ch_irq_msk,
-    0x0001f098 + 0x4000 * GSI_EE_AP);
+    0x0001f098 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_MSK, cntxt_src_ev_ch_irq_msk,
-    0x0001f09c + 0x4000 * GSI_EE_AP);
+    0x0001f09c + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_CLR, cntxt_src_ch_irq_clr,
-    0x0001f0a0 + 0x4000 * GSI_EE_AP);
+    0x0001f0a0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_CLR, cntxt_src_ev_ch_irq_clr,
-    0x0001f0a4 + 0x4000 * GSI_EE_AP);
+    0x0001f0a4 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x0001f0b0 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x0001f0b0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_MSK, cntxt_src_ieob_irq_msk,
-    0x0001f0b8 + 0x4000 * GSI_EE_AP);
+    0x0001f0b8 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_CLR, cntxt_src_ieob_irq_clr,
-    0x0001f0c0 + 0x4000 * GSI_EE_AP);
+    0x0001f0c0 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x0001f100 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x0001f100 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x0001f108 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x0001f108 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x0001f110 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x0001f110 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x0001f118 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x0001f118 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x0001f120 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x0001f120 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x0001f128 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x0001f128 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_intset_fmask[] = {
 	[INTYPE]					= BIT(0)
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x0001f180 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x0001f180 + 0x4000 * DMA_EE_AP);
 
-REG_FIELDS(ERROR_LOG, error_log, 0x0001f200 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(ERROR_LOG, error_log, 0x0001f200 + 0x4000 * DMA_EE_AP);
 
-REG(ERROR_LOG_CLR, error_log_clr, 0x0001f210 + 0x4000 * GSI_EE_AP);
+REG(ERROR_LOG_CLR, error_log_clr, 0x0001f210 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_scratch_0_fmask[] = {
 	[INTER_EE_RESULT]				= GENMASK(2, 0),
@@ -229,7 +229,7 @@ static const u32 reg_cntxt_scratch_0_fmask[] = {
 						/* Bits 8-31 reserved */
 };
 
-REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x0001f400 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x0001f400 + 0x4000 * DMA_EE_AP);
 
 static const struct reg *reg_array[] = {
 	[INTER_EE_SRC_CH_IRQ_MSK]	= &reg_inter_ee_src_ch_irq_msk,

--- a/drivers/net/ipa/reg/gsi_reg-v3.5.1.c
+++ b/drivers/net/ipa/reg/gsi_reg-v3.5.1.c
@@ -9,10 +9,10 @@
 #include "../gsi_reg.h"
 
 REG(INTER_EE_SRC_CH_IRQ_MSK, inter_ee_src_ch_irq_msk,
-    0x0000c020 + 0x1000 * GSI_EE_AP);
+    0x0000c020 + 0x1000 * DMA_EE_AP);
 
 REG(INTER_EE_SRC_EV_CH_IRQ_MSK, inter_ee_src_ev_ch_irq_msk,
-    0x0000c024 + 0x1000 * GSI_EE_AP);
+    0x0000c024 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ch_c_cntxt_0_fmask[] = {
 	[CHTYPE_PROTOCOL]				= GENMASK(2, 0),
@@ -27,7 +27,7 @@ static const u32 reg_ch_c_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_0, ch_c_cntxt_0,
-		  0x0001c000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001c000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_cntxt_1_fmask[] = {
 	[CH_R_LENGTH]					= GENMASK(15, 0),
@@ -35,11 +35,11 @@ static const u32 reg_ch_c_cntxt_1_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_1, ch_c_cntxt_1,
-		  0x0001c004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001c004 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0001c008 + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0001c008 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0001c00c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0001c00c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_qos_fmask[] = {
 	[WRR_WEIGHT]					= GENMASK(3, 0),
@@ -49,7 +49,7 @@ static const u32 reg_ch_c_qos_fmask[] = {
 						/* Bits 10-31 reserved */
 };
 
-REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0001c05c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0001c05c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_error_log_fmask[] = {
 	[ERR_ARG3]					= GENMASK(3, 0),
@@ -63,16 +63,16 @@ static const u32 reg_error_log_fmask[] = {
 };
 
 REG_STRIDE(CH_C_SCRATCH_0, ch_c_scratch_0,
-	   0x0001c060 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c060 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_1, ch_c_scratch_1,
-	   0x0001c064 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c064 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_2, ch_c_scratch_2,
-	   0x0001c068 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c068 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_3, ch_c_scratch_3,
-	   0x0001c06c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c06c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 	[EV_CHTYPE]					= GENMASK(3, 0),
@@ -85,23 +85,23 @@ static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_0, ev_ch_e_cntxt_0,
-		  0x0001d000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001d000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_1_fmask[] = {
 	[R_LENGTH]					= GENMASK(15, 0),
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_1, ev_ch_e_cntxt_1,
-		  0x0001d004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001d004 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_2, ev_ch_e_cntxt_2,
-	   0x0001d008 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d008 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_3, ev_ch_e_cntxt_3,
-	   0x0001d00c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d00c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_4, ev_ch_e_cntxt_4,
-	   0x0001d010 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d010 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 	[EV_MODT]					= GENMASK(15, 0),
@@ -110,41 +110,41 @@ static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_8, ev_ch_e_cntxt_8,
-		  0x0001d020 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001d020 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_9, ev_ch_e_cntxt_9,
-	   0x0001d024 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d024 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_10, ev_ch_e_cntxt_10,
-	   0x0001d028 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d028 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_11, ev_ch_e_cntxt_11,
-	   0x0001d02c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d02c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_12, ev_ch_e_cntxt_12,
-	   0x0001d030 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d030 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_13, ev_ch_e_cntxt_13,
-	   0x0001d034 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d034 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_0, ev_ch_e_scratch_0,
-	   0x0001d048 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d048 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_1, ev_ch_e_scratch_1,
-	   0x0001d04c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d04c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_DOORBELL_0, ch_c_doorbell_0,
-	   0x0001e000 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x0001e000 + 0x4000 * DMA_EE_AP, 0x08);
 
 REG_STRIDE(EV_CH_E_DOORBELL_0, ev_ch_e_doorbell_0,
-	   0x0001e100 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x0001e100 + 0x4000 * DMA_EE_AP, 0x08);
 
 static const u32 reg_gsi_status_fmask[] = {
 	[ENABLED]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(GSI_STATUS, gsi_status, 0x0001f000 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GSI_STATUS, gsi_status, 0x0001f000 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ch_cmd_fmask[] = {
 	[CH_CHID]					= GENMASK(7, 0),
@@ -152,7 +152,7 @@ static const u32 reg_ch_cmd_fmask[] = {
 	[CH_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(CH_CMD, ch_cmd, 0x0001f008 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CH_CMD, ch_cmd, 0x0001f008 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_CHID]					= GENMASK(7, 0),
@@ -160,7 +160,7 @@ static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x0001f010 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x0001f010 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_generic_cmd_fmask[] = {
 	[GENERIC_OPCODE]				= GENMASK(4, 0),
@@ -169,7 +169,7 @@ static const u32 reg_generic_cmd_fmask[] = {
 						/* Bits 14-31 reserved */
 };
 
-REG_FIELDS(GENERIC_CMD, generic_cmd, 0x0001f018 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GENERIC_CMD, generic_cmd, 0x0001f018 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_hw_param_2_fmask[] = {
 	[IRAM_SIZE]					= GENMASK(2, 0),
@@ -180,58 +180,58 @@ static const u32 reg_hw_param_2_fmask[] = {
 						/* Bits 15-31 reserved */
 };
 
-REG_FIELDS(HW_PARAM_2, hw_param_2, 0x0001f040 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(HW_PARAM_2, hw_param_2, 0x0001f040 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x0001f080 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x0001f080 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x0001f088 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x0001f088 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x0001f090 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x0001f090 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x0001f094 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x0001f094 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_MSK, cntxt_src_ch_irq_msk,
-    0x0001f098 + 0x4000 * GSI_EE_AP);
+    0x0001f098 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_MSK, cntxt_src_ev_ch_irq_msk,
-    0x0001f09c + 0x4000 * GSI_EE_AP);
+    0x0001f09c + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_CLR, cntxt_src_ch_irq_clr,
-    0x0001f0a0 + 0x4000 * GSI_EE_AP);
+    0x0001f0a0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_CLR, cntxt_src_ev_ch_irq_clr,
-    0x0001f0a4 + 0x4000 * GSI_EE_AP);
+    0x0001f0a4 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x0001f0b0 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x0001f0b0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_MSK, cntxt_src_ieob_irq_msk,
-    0x0001f0b8 + 0x4000 * GSI_EE_AP);
+    0x0001f0b8 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_CLR, cntxt_src_ieob_irq_clr,
-    0x0001f0c0 + 0x4000 * GSI_EE_AP);
+    0x0001f0c0 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x0001f100 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x0001f100 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x0001f108 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x0001f108 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x0001f110 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x0001f110 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x0001f118 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x0001f118 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x0001f120 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x0001f120 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x0001f128 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x0001f128 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_intset_fmask[] = {
 	[INTYPE]					= BIT(0)
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x0001f180 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x0001f180 + 0x4000 * DMA_EE_AP);
 
-REG_FIELDS(ERROR_LOG, error_log, 0x0001f200 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(ERROR_LOG, error_log, 0x0001f200 + 0x4000 * DMA_EE_AP);
 
-REG(ERROR_LOG_CLR, error_log_clr, 0x0001f210 + 0x4000 * GSI_EE_AP);
+REG(ERROR_LOG_CLR, error_log_clr, 0x0001f210 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_scratch_0_fmask[] = {
 	[INTER_EE_RESULT]				= GENMASK(2, 0),
@@ -240,7 +240,7 @@ static const u32 reg_cntxt_scratch_0_fmask[] = {
 						/* Bits 8-31 reserved */
 };
 
-REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x0001f400 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x0001f400 + 0x4000 * DMA_EE_AP);
 
 static const struct reg *reg_array[] = {
 	[INTER_EE_SRC_CH_IRQ_MSK]	= &reg_inter_ee_src_ch_irq_msk,

--- a/drivers/net/ipa/reg/gsi_reg-v4.0.c
+++ b/drivers/net/ipa/reg/gsi_reg-v4.0.c
@@ -9,10 +9,10 @@
 #include "../gsi_reg.h"
 
 REG(INTER_EE_SRC_CH_IRQ_MSK, inter_ee_src_ch_irq_msk,
-    0x0000c020 + 0x1000 * GSI_EE_AP);
+    0x0000c020 + 0x1000 * DMA_EE_AP);
 
 REG(INTER_EE_SRC_EV_CH_IRQ_MSK, inter_ee_src_ev_ch_irq_msk,
-    0x0000c024 + 0x1000 * GSI_EE_AP);
+    0x0000c024 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ch_c_cntxt_0_fmask[] = {
 	[CHTYPE_PROTOCOL]				= GENMASK(2, 0),
@@ -27,7 +27,7 @@ static const u32 reg_ch_c_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_0, ch_c_cntxt_0,
-		  0x0001c000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001c000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_cntxt_1_fmask[] = {
 	[CH_R_LENGTH]					= GENMASK(15, 0),
@@ -35,11 +35,11 @@ static const u32 reg_ch_c_cntxt_1_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_1, ch_c_cntxt_1,
-		  0x0001c004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001c004 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0001c008 + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0001c008 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0001c00c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0001c00c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_qos_fmask[] = {
 	[WRR_WEIGHT]					= GENMASK(3, 0),
@@ -50,7 +50,7 @@ static const u32 reg_ch_c_qos_fmask[] = {
 						/* Bits 11-31 reserved */
 };
 
-REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0001c05c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0001c05c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_error_log_fmask[] = {
 	[ERR_ARG3]					= GENMASK(3, 0),
@@ -64,16 +64,16 @@ static const u32 reg_error_log_fmask[] = {
 };
 
 REG_STRIDE(CH_C_SCRATCH_0, ch_c_scratch_0,
-	   0x0001c060 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c060 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_1, ch_c_scratch_1,
-	   0x0001c064 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c064 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_2, ch_c_scratch_2,
-	   0x0001c068 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c068 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_3, ch_c_scratch_3,
-	   0x0001c06c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001c06c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 	[EV_CHTYPE]					= GENMASK(3, 0),
@@ -86,23 +86,23 @@ static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_0, ev_ch_e_cntxt_0,
-		  0x0001d000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001d000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_1_fmask[] = {
 	[R_LENGTH]					= GENMASK(15, 0),
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_1, ev_ch_e_cntxt_1,
-		  0x0001d004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001d004 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_2, ev_ch_e_cntxt_2,
-	   0x0001d008 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d008 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_3, ev_ch_e_cntxt_3,
-	   0x0001d00c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d00c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_4, ev_ch_e_cntxt_4,
-	   0x0001d010 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d010 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 	[EV_MODT]					= GENMASK(15, 0),
@@ -111,41 +111,41 @@ static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_8, ev_ch_e_cntxt_8,
-		  0x0001d020 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0001d020 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_9, ev_ch_e_cntxt_9,
-	   0x0001d024 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d024 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_10, ev_ch_e_cntxt_10,
-	   0x0001d028 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d028 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_11, ev_ch_e_cntxt_11,
-	   0x0001d02c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d02c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_12, ev_ch_e_cntxt_12,
-	   0x0001d030 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d030 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_13, ev_ch_e_cntxt_13,
-	   0x0001d034 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d034 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_0, ev_ch_e_scratch_0,
-	   0x0001d048 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d048 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_1, ev_ch_e_scratch_1,
-	   0x0001d04c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001d04c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_DOORBELL_0, ch_c_doorbell_0,
-	   0x0001e000 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x0001e000 + 0x4000 * DMA_EE_AP, 0x08);
 
 REG_STRIDE(EV_CH_E_DOORBELL_0, ev_ch_e_doorbell_0,
-	   0x0001e100 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x0001e100 + 0x4000 * DMA_EE_AP, 0x08);
 
 static const u32 reg_gsi_status_fmask[] = {
 	[ENABLED]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(GSI_STATUS, gsi_status, 0x0001f000 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GSI_STATUS, gsi_status, 0x0001f000 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ch_cmd_fmask[] = {
 	[CH_CHID]					= GENMASK(7, 0),
@@ -153,7 +153,7 @@ static const u32 reg_ch_cmd_fmask[] = {
 	[CH_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(CH_CMD, ch_cmd, 0x0001f008 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CH_CMD, ch_cmd, 0x0001f008 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_CHID]					= GENMASK(7, 0),
@@ -161,7 +161,7 @@ static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x0001f010 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x0001f010 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_generic_cmd_fmask[] = {
 	[GENERIC_OPCODE]				= GENMASK(4, 0),
@@ -170,7 +170,7 @@ static const u32 reg_generic_cmd_fmask[] = {
 						/* Bits 14-31 reserved */
 };
 
-REG_FIELDS(GENERIC_CMD, generic_cmd, 0x0001f018 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GENERIC_CMD, generic_cmd, 0x0001f018 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_hw_param_2_fmask[] = {
 	[IRAM_SIZE]					= GENMASK(2, 0),
@@ -185,58 +185,58 @@ static const u32 reg_hw_param_2_fmask[] = {
 						/* Bits 30-31 reserved */
 };
 
-REG_FIELDS(HW_PARAM_2, hw_param_2, 0x0001f040 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(HW_PARAM_2, hw_param_2, 0x0001f040 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x0001f080 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x0001f080 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x0001f088 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x0001f088 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x0001f090 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x0001f090 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x0001f094 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x0001f094 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_MSK, cntxt_src_ch_irq_msk,
-    0x0001f098 + 0x4000 * GSI_EE_AP);
+    0x0001f098 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_MSK, cntxt_src_ev_ch_irq_msk,
-    0x0001f09c + 0x4000 * GSI_EE_AP);
+    0x0001f09c + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_CLR, cntxt_src_ch_irq_clr,
-    0x0001f0a0 + 0x4000 * GSI_EE_AP);
+    0x0001f0a0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_CLR, cntxt_src_ev_ch_irq_clr,
-    0x0001f0a4 + 0x4000 * GSI_EE_AP);
+    0x0001f0a4 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x0001f0b0 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x0001f0b0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_MSK, cntxt_src_ieob_irq_msk,
-    0x0001f0b8 + 0x4000 * GSI_EE_AP);
+    0x0001f0b8 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_CLR, cntxt_src_ieob_irq_clr,
-    0x0001f0c0 + 0x4000 * GSI_EE_AP);
+    0x0001f0c0 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x0001f100 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x0001f100 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x0001f108 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x0001f108 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x0001f110 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x0001f110 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x0001f118 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x0001f118 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x0001f120 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x0001f120 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x0001f128 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x0001f128 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_intset_fmask[] = {
 	[INTYPE]					= BIT(0)
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x0001f180 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x0001f180 + 0x4000 * DMA_EE_AP);
 
-REG_FIELDS(ERROR_LOG, error_log, 0x0001f200 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(ERROR_LOG, error_log, 0x0001f200 + 0x4000 * DMA_EE_AP);
 
-REG(ERROR_LOG_CLR, error_log_clr, 0x0001f210 + 0x4000 * GSI_EE_AP);
+REG(ERROR_LOG_CLR, error_log_clr, 0x0001f210 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_scratch_0_fmask[] = {
 	[INTER_EE_RESULT]				= GENMASK(2, 0),
@@ -245,7 +245,7 @@ static const u32 reg_cntxt_scratch_0_fmask[] = {
 						/* Bits 8-31 reserved */
 };
 
-REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x0001f400 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x0001f400 + 0x4000 * DMA_EE_AP);
 
 static const struct reg *reg_array[] = {
 	[INTER_EE_SRC_CH_IRQ_MSK]	= &reg_inter_ee_src_ch_irq_msk,

--- a/drivers/net/ipa/reg/gsi_reg-v4.11.c
+++ b/drivers/net/ipa/reg/gsi_reg-v4.11.c
@@ -9,10 +9,10 @@
 #include "../gsi_reg.h"
 
 REG(INTER_EE_SRC_CH_IRQ_MSK, inter_ee_src_ch_irq_msk,
-    0x0000c020 + 0x1000 * GSI_EE_AP);
+    0x0000c020 + 0x1000 * DMA_EE_AP);
 
 REG(INTER_EE_SRC_EV_CH_IRQ_MSK, inter_ee_src_ev_ch_irq_msk,
-    0x0000c024 + 0x1000 * GSI_EE_AP);
+    0x0000c024 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ch_c_cntxt_0_fmask[] = {
 	[CHTYPE_PROTOCOL]				= GENMASK(2, 0),
@@ -27,7 +27,7 @@ static const u32 reg_ch_c_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_0, ch_c_cntxt_0,
-		  0x0000f000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0000f000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_cntxt_1_fmask[] = {
 	[CH_R_LENGTH]					= GENMASK(19, 0),
@@ -35,11 +35,11 @@ static const u32 reg_ch_c_cntxt_1_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_1, ch_c_cntxt_1,
-		  0x0000f004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0000f004 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0000f008 + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0000f008 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0000f00c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0000f00c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_qos_fmask[] = {
 	[WRR_WEIGHT]					= GENMASK(3, 0),
@@ -53,7 +53,7 @@ static const u32 reg_ch_c_qos_fmask[] = {
 						/* Bits 25-31 reserved */
 };
 
-REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0000f05c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0000f05c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_error_log_fmask[] = {
 	[ERR_ARG3]					= GENMASK(3, 0),
@@ -67,16 +67,16 @@ static const u32 reg_error_log_fmask[] = {
 };
 
 REG_STRIDE(CH_C_SCRATCH_0, ch_c_scratch_0,
-	   0x0000f060 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f060 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_1, ch_c_scratch_1,
-	   0x0000f064 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f064 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_2, ch_c_scratch_2,
-	   0x0000f068 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f068 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_3, ch_c_scratch_3,
-	   0x0000f06c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f06c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 	[EV_CHTYPE]					= GENMASK(3, 0),
@@ -89,23 +89,23 @@ static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_0, ev_ch_e_cntxt_0,
-		  0x00010000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x00010000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_1_fmask[] = {
 	[R_LENGTH]					= GENMASK(19, 0),
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_1, ev_ch_e_cntxt_1,
-		  0x00010004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x00010004 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_2, ev_ch_e_cntxt_2,
-	   0x00010008 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010008 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_3, ev_ch_e_cntxt_3,
-	   0x0001000c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001000c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_4, ev_ch_e_cntxt_4,
-	   0x00010010 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010010 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 	[EV_MODT]					= GENMASK(15, 0),
@@ -114,41 +114,41 @@ static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_8, ev_ch_e_cntxt_8,
-		  0x00010020 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x00010020 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_9, ev_ch_e_cntxt_9,
-	   0x00010024 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010024 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_10, ev_ch_e_cntxt_10,
-	   0x00010028 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010028 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_11, ev_ch_e_cntxt_11,
-	   0x0001002c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001002c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_12, ev_ch_e_cntxt_12,
-	   0x00010030 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010030 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_13, ev_ch_e_cntxt_13,
-	   0x00010034 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010034 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_0, ev_ch_e_scratch_0,
-	   0x00010048 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010048 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_1, ev_ch_e_scratch_1,
-	   0x0001004c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001004c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_DOORBELL_0, ch_c_doorbell_0,
-	   0x00011000 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x00011000 + 0x4000 * DMA_EE_AP, 0x08);
 
 REG_STRIDE(EV_CH_E_DOORBELL_0, ev_ch_e_doorbell_0,
-	   0x00011100 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x00011100 + 0x4000 * DMA_EE_AP, 0x08);
 
 static const u32 reg_gsi_status_fmask[] = {
 	[ENABLED]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(GSI_STATUS, gsi_status, 0x00012000 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GSI_STATUS, gsi_status, 0x00012000 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ch_cmd_fmask[] = {
 	[CH_CHID]					= GENMASK(7, 0),
@@ -156,7 +156,7 @@ static const u32 reg_ch_cmd_fmask[] = {
 	[CH_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(CH_CMD, ch_cmd, 0x00012008 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CH_CMD, ch_cmd, 0x00012008 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_CHID]					= GENMASK(7, 0),
@@ -164,7 +164,7 @@ static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x00012010 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x00012010 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_generic_cmd_fmask[] = {
 	[GENERIC_OPCODE]				= GENMASK(4, 0),
@@ -174,7 +174,7 @@ static const u32 reg_generic_cmd_fmask[] = {
 	[GENERIC_PARAMS]				= GENMASK(31, 24),
 };
 
-REG_FIELDS(GENERIC_CMD, generic_cmd, 0x00012018 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GENERIC_CMD, generic_cmd, 0x00012018 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_hw_param_2_fmask[] = {
 	[IRAM_SIZE]					= GENMASK(2, 0),
@@ -190,58 +190,58 @@ static const u32 reg_hw_param_2_fmask[] = {
 	[GSI_USE_INTER_EE]				= BIT(31),
 };
 
-REG_FIELDS(HW_PARAM_2, hw_param_2, 0x00012040 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(HW_PARAM_2, hw_param_2, 0x00012040 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x00012080 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x00012080 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x00012088 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x00012088 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x00012090 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x00012090 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x00012094 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x00012094 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_MSK, cntxt_src_ch_irq_msk,
-    0x00012098 + 0x4000 * GSI_EE_AP);
+    0x00012098 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_MSK, cntxt_src_ev_ch_irq_msk,
-    0x0001209c + 0x4000 * GSI_EE_AP);
+    0x0001209c + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_CLR, cntxt_src_ch_irq_clr,
-    0x000120a0 + 0x4000 * GSI_EE_AP);
+    0x000120a0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_CLR, cntxt_src_ev_ch_irq_clr,
-    0x000120a4 + 0x4000 * GSI_EE_AP);
+    0x000120a4 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x000120b0 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x000120b0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_MSK, cntxt_src_ieob_irq_msk,
-    0x000120b8 + 0x4000 * GSI_EE_AP);
+    0x000120b8 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_CLR, cntxt_src_ieob_irq_clr,
-    0x000120c0 + 0x4000 * GSI_EE_AP);
+    0x000120c0 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x00012100 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x00012100 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x00012108 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x00012108 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x00012110 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x00012110 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x00012118 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x00012118 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x00012120 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x00012120 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x00012128 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x00012128 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_intset_fmask[] = {
 	[INTYPE]					= BIT(0)
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x00012180 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x00012180 + 0x4000 * DMA_EE_AP);
 
-REG_FIELDS(ERROR_LOG, error_log, 0x00012200 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(ERROR_LOG, error_log, 0x00012200 + 0x4000 * DMA_EE_AP);
 
-REG(ERROR_LOG_CLR, error_log_clr, 0x00012210 + 0x4000 * GSI_EE_AP);
+REG(ERROR_LOG_CLR, error_log_clr, 0x00012210 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_scratch_0_fmask[] = {
 	[INTER_EE_RESULT]				= GENMASK(2, 0),
@@ -250,7 +250,7 @@ static const u32 reg_cntxt_scratch_0_fmask[] = {
 						/* Bits 8-31 reserved */
 };
 
-REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x00012400 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x00012400 + 0x4000 * DMA_EE_AP);
 
 static const struct reg *reg_array[] = {
 	[INTER_EE_SRC_CH_IRQ_MSK]	= &reg_inter_ee_src_ch_irq_msk,

--- a/drivers/net/ipa/reg/gsi_reg-v4.5.c
+++ b/drivers/net/ipa/reg/gsi_reg-v4.5.c
@@ -9,10 +9,10 @@
 #include "../gsi_reg.h"
 
 REG(INTER_EE_SRC_CH_IRQ_MSK, inter_ee_src_ch_irq_msk,
-    0x0000c020 + 0x1000 * GSI_EE_AP);
+    0x0000c020 + 0x1000 * DMA_EE_AP);
 
 REG(INTER_EE_SRC_EV_CH_IRQ_MSK, inter_ee_src_ev_ch_irq_msk,
-    0x0000c024 + 0x1000 * GSI_EE_AP);
+    0x0000c024 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ch_c_cntxt_0_fmask[] = {
 	[CHTYPE_PROTOCOL]				= GENMASK(2, 0),
@@ -27,7 +27,7 @@ static const u32 reg_ch_c_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_0, ch_c_cntxt_0,
-		  0x0000f000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0000f000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_cntxt_1_fmask[] = {
 	[CH_R_LENGTH]					= GENMASK(15, 0),
@@ -35,11 +35,11 @@ static const u32 reg_ch_c_cntxt_1_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_1, ch_c_cntxt_1,
-		  0x0000f004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0000f004 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0000f008 + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0000f008 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0000f00c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0000f00c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_qos_fmask[] = {
 	[WRR_WEIGHT]					= GENMASK(3, 0),
@@ -52,7 +52,7 @@ static const u32 reg_ch_c_qos_fmask[] = {
 						/* Bits 24-31 reserved */
 };
 
-REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0000f05c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0000f05c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_error_log_fmask[] = {
 	[ERR_ARG3]					= GENMASK(3, 0),
@@ -66,16 +66,16 @@ static const u32 reg_error_log_fmask[] = {
 };
 
 REG_STRIDE(CH_C_SCRATCH_0, ch_c_scratch_0,
-	   0x0000f060 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f060 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_1, ch_c_scratch_1,
-	   0x0000f064 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f064 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_2, ch_c_scratch_2,
-	   0x0000f068 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f068 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_3, ch_c_scratch_3,
-	   0x0000f06c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f06c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 	[EV_CHTYPE]					= GENMASK(3, 0),
@@ -88,23 +88,23 @@ static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_0, ev_ch_e_cntxt_0,
-		  0x00010000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x00010000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_1_fmask[] = {
 	[R_LENGTH]					= GENMASK(15, 0),
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_1, ev_ch_e_cntxt_1,
-		  0x00010004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x00010004 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_2, ev_ch_e_cntxt_2,
-	   0x00010008 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010008 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_3, ev_ch_e_cntxt_3,
-	   0x0001000c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001000c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_4, ev_ch_e_cntxt_4,
-	   0x00010010 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010010 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 	[EV_MODT]					= GENMASK(15, 0),
@@ -113,41 +113,41 @@ static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_8, ev_ch_e_cntxt_8,
-		  0x00010020 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x00010020 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_9, ev_ch_e_cntxt_9,
-	   0x00010024 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010024 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_10, ev_ch_e_cntxt_10,
-	   0x00010028 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010028 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_11, ev_ch_e_cntxt_11,
-	   0x0001002c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001002c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_12, ev_ch_e_cntxt_12,
-	   0x00010030 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010030 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_13, ev_ch_e_cntxt_13,
-	   0x00010034 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010034 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_0, ev_ch_e_scratch_0,
-	   0x00010048 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010048 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_1, ev_ch_e_scratch_1,
-	   0x0001004c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001004c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_DOORBELL_0, ch_c_doorbell_0,
-	   0x00011000 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x00011000 + 0x4000 * DMA_EE_AP, 0x08);
 
 REG_STRIDE(EV_CH_E_DOORBELL_0, ev_ch_e_doorbell_0,
-	   0x00011100 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x00011100 + 0x4000 * DMA_EE_AP, 0x08);
 
 static const u32 reg_gsi_status_fmask[] = {
 	[ENABLED]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(GSI_STATUS, gsi_status, 0x00012000 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GSI_STATUS, gsi_status, 0x00012000 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ch_cmd_fmask[] = {
 	[CH_CHID]					= GENMASK(7, 0),
@@ -155,7 +155,7 @@ static const u32 reg_ch_cmd_fmask[] = {
 	[CH_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(CH_CMD, ch_cmd, 0x00012008 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CH_CMD, ch_cmd, 0x00012008 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_CHID]					= GENMASK(7, 0),
@@ -163,7 +163,7 @@ static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x00012010 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x00012010 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_generic_cmd_fmask[] = {
 	[GENERIC_OPCODE]				= GENMASK(4, 0),
@@ -172,7 +172,7 @@ static const u32 reg_generic_cmd_fmask[] = {
 						/* Bits 14-31 reserved */
 };
 
-REG_FIELDS(GENERIC_CMD, generic_cmd, 0x00012018 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GENERIC_CMD, generic_cmd, 0x00012018 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_hw_param_2_fmask[] = {
 	[IRAM_SIZE]					= GENMASK(2, 0),
@@ -188,58 +188,58 @@ static const u32 reg_hw_param_2_fmask[] = {
 	[GSI_USE_INTER_EE]				= BIT(31),
 };
 
-REG_FIELDS(HW_PARAM_2, hw_param_2, 0x00012040 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(HW_PARAM_2, hw_param_2, 0x00012040 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x00012080 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x00012080 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x00012088 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x00012088 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x00012090 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x00012090 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x00012094 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x00012094 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_MSK, cntxt_src_ch_irq_msk,
-    0x00012098 + 0x4000 * GSI_EE_AP);
+    0x00012098 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_MSK, cntxt_src_ev_ch_irq_msk,
-    0x0001209c + 0x4000 * GSI_EE_AP);
+    0x0001209c + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_CLR, cntxt_src_ch_irq_clr,
-    0x000120a0 + 0x4000 * GSI_EE_AP);
+    0x000120a0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_CLR, cntxt_src_ev_ch_irq_clr,
-    0x000120a4 + 0x4000 * GSI_EE_AP);
+    0x000120a4 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x000120b0 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x000120b0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_MSK, cntxt_src_ieob_irq_msk,
-    0x000120b8 + 0x4000 * GSI_EE_AP);
+    0x000120b8 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_CLR, cntxt_src_ieob_irq_clr,
-    0x000120c0 + 0x4000 * GSI_EE_AP);
+    0x000120c0 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x00012100 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x00012100 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x00012108 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x00012108 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x00012110 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x00012110 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x00012118 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x00012118 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x00012120 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x00012120 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x00012128 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x00012128 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_intset_fmask[] = {
 	[INTYPE]					= BIT(0)
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x00012180 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x00012180 + 0x4000 * DMA_EE_AP);
 
-REG_FIELDS(ERROR_LOG, error_log, 0x00012200 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(ERROR_LOG, error_log, 0x00012200 + 0x4000 * DMA_EE_AP);
 
-REG(ERROR_LOG_CLR, error_log_clr, 0x00012210 + 0x4000 * GSI_EE_AP);
+REG(ERROR_LOG_CLR, error_log_clr, 0x00012210 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_scratch_0_fmask[] = {
 	[INTER_EE_RESULT]				= GENMASK(2, 0),
@@ -248,7 +248,7 @@ static const u32 reg_cntxt_scratch_0_fmask[] = {
 						/* Bits 8-31 reserved */
 };
 
-REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x00012400 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x00012400 + 0x4000 * DMA_EE_AP);
 
 static const struct reg *reg_array[] = {
 	[INTER_EE_SRC_CH_IRQ_MSK]	= &reg_inter_ee_src_ch_irq_msk,

--- a/drivers/net/ipa/reg/gsi_reg-v4.9.c
+++ b/drivers/net/ipa/reg/gsi_reg-v4.9.c
@@ -9,10 +9,10 @@
 #include "../gsi_reg.h"
 
 REG(INTER_EE_SRC_CH_IRQ_MSK, inter_ee_src_ch_irq_msk,
-    0x0000c020 + 0x1000 * GSI_EE_AP);
+    0x0000c020 + 0x1000 * DMA_EE_AP);
 
 REG(INTER_EE_SRC_EV_CH_IRQ_MSK, inter_ee_src_ev_ch_irq_msk,
-    0x0000c024 + 0x1000 * GSI_EE_AP);
+    0x0000c024 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ch_c_cntxt_0_fmask[] = {
 	[CHTYPE_PROTOCOL]				= GENMASK(2, 0),
@@ -27,7 +27,7 @@ static const u32 reg_ch_c_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_0, ch_c_cntxt_0,
-		  0x0000f000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0000f000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_cntxt_1_fmask[] = {
 	[CH_R_LENGTH]					= GENMASK(19, 0),
@@ -35,11 +35,11 @@ static const u32 reg_ch_c_cntxt_1_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(CH_C_CNTXT_1, ch_c_cntxt_1,
-		  0x0000f004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x0000f004 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0000f008 + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_2, ch_c_cntxt_2, 0x0000f008 + 0x4000 * DMA_EE_AP, 0x80);
 
-REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0000f00c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE(CH_C_CNTXT_3, ch_c_cntxt_3, 0x0000f00c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ch_c_qos_fmask[] = {
 	[WRR_WEIGHT]					= GENMASK(3, 0),
@@ -53,7 +53,7 @@ static const u32 reg_ch_c_qos_fmask[] = {
 						/* Bits 25-31 reserved */
 };
 
-REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0000f05c + 0x4000 * GSI_EE_AP, 0x80);
+REG_STRIDE_FIELDS(CH_C_QOS, ch_c_qos, 0x0000f05c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_error_log_fmask[] = {
 	[ERR_ARG3]					= GENMASK(3, 0),
@@ -67,16 +67,16 @@ static const u32 reg_error_log_fmask[] = {
 };
 
 REG_STRIDE(CH_C_SCRATCH_0, ch_c_scratch_0,
-	   0x0000f060 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f060 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_1, ch_c_scratch_1,
-	   0x0000f064 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f064 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_2, ch_c_scratch_2,
-	   0x0000f068 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f068 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_SCRATCH_3, ch_c_scratch_3,
-	   0x0000f06c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0000f06c + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 	[EV_CHTYPE]					= GENMASK(3, 0),
@@ -89,23 +89,23 @@ static const u32 reg_ev_ch_e_cntxt_0_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_0, ev_ch_e_cntxt_0,
-		  0x00010000 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x00010000 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_1_fmask[] = {
 	[R_LENGTH]					= GENMASK(15, 0),
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_1, ev_ch_e_cntxt_1,
-		  0x00010004 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x00010004 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_2, ev_ch_e_cntxt_2,
-	   0x00010008 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010008 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_3, ev_ch_e_cntxt_3,
-	   0x0001000c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001000c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_4, ev_ch_e_cntxt_4,
-	   0x00010010 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010010 + 0x4000 * DMA_EE_AP, 0x80);
 
 static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 	[EV_MODT]					= GENMASK(15, 0),
@@ -114,41 +114,41 @@ static const u32 reg_ev_ch_e_cntxt_8_fmask[] = {
 };
 
 REG_STRIDE_FIELDS(EV_CH_E_CNTXT_8, ev_ch_e_cntxt_8,
-		  0x00010020 + 0x4000 * GSI_EE_AP, 0x80);
+		  0x00010020 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_9, ev_ch_e_cntxt_9,
-	   0x00010024 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010024 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_10, ev_ch_e_cntxt_10,
-	   0x00010028 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010028 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_11, ev_ch_e_cntxt_11,
-	   0x0001002c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001002c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_12, ev_ch_e_cntxt_12,
-	   0x00010030 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010030 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_CNTXT_13, ev_ch_e_cntxt_13,
-	   0x00010034 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010034 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_0, ev_ch_e_scratch_0,
-	   0x00010048 + 0x4000 * GSI_EE_AP, 0x80);
+	   0x00010048 + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(EV_CH_E_SCRATCH_1, ev_ch_e_scratch_1,
-	   0x0001004c + 0x4000 * GSI_EE_AP, 0x80);
+	   0x0001004c + 0x4000 * DMA_EE_AP, 0x80);
 
 REG_STRIDE(CH_C_DOORBELL_0, ch_c_doorbell_0,
-	   0x00011000 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x00011000 + 0x4000 * DMA_EE_AP, 0x08);
 
 REG_STRIDE(EV_CH_E_DOORBELL_0, ev_ch_e_doorbell_0,
-	   0x00011100 + 0x4000 * GSI_EE_AP, 0x08);
+	   0x00011100 + 0x4000 * DMA_EE_AP, 0x08);
 
 static const u32 reg_gsi_status_fmask[] = {
 	[ENABLED]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(GSI_STATUS, gsi_status, 0x00012000 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GSI_STATUS, gsi_status, 0x00012000 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ch_cmd_fmask[] = {
 	[CH_CHID]					= GENMASK(7, 0),
@@ -156,7 +156,7 @@ static const u32 reg_ch_cmd_fmask[] = {
 	[CH_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(CH_CMD, ch_cmd, 0x00012008 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CH_CMD, ch_cmd, 0x00012008 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_CHID]					= GENMASK(7, 0),
@@ -164,7 +164,7 @@ static const u32 reg_ev_ch_cmd_fmask[] = {
 	[EV_OPCODE]					= GENMASK(31, 24),
 };
 
-REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x00012010 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(EV_CH_CMD, ev_ch_cmd, 0x00012010 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_generic_cmd_fmask[] = {
 	[GENERIC_OPCODE]				= GENMASK(4, 0),
@@ -173,7 +173,7 @@ static const u32 reg_generic_cmd_fmask[] = {
 						/* Bits 14-31 reserved */
 };
 
-REG_FIELDS(GENERIC_CMD, generic_cmd, 0x00012018 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(GENERIC_CMD, generic_cmd, 0x00012018 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_hw_param_2_fmask[] = {
 	[IRAM_SIZE]					= GENMASK(2, 0),
@@ -189,58 +189,58 @@ static const u32 reg_hw_param_2_fmask[] = {
 	[GSI_USE_INTER_EE]				= BIT(31),
 };
 
-REG_FIELDS(HW_PARAM_2, hw_param_2, 0x00012040 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(HW_PARAM_2, hw_param_2, 0x00012040 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x00012080 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ, cntxt_type_irq, 0x00012080 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x00012088 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_TYPE_IRQ_MSK, cntxt_type_irq_msk, 0x00012088 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x00012090 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_CH_IRQ, cntxt_src_ch_irq, 0x00012090 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x00012094 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_EV_CH_IRQ, cntxt_src_ev_ch_irq, 0x00012094 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_MSK, cntxt_src_ch_irq_msk,
-    0x00012098 + 0x4000 * GSI_EE_AP);
+    0x00012098 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_MSK, cntxt_src_ev_ch_irq_msk,
-    0x0001209c + 0x4000 * GSI_EE_AP);
+    0x0001209c + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_CH_IRQ_CLR, cntxt_src_ch_irq_clr,
-    0x000120a0 + 0x4000 * GSI_EE_AP);
+    0x000120a0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_EV_CH_IRQ_CLR, cntxt_src_ev_ch_irq_clr,
-    0x000120a4 + 0x4000 * GSI_EE_AP);
+    0x000120a4 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x000120b0 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_SRC_IEOB_IRQ, cntxt_src_ieob_irq, 0x000120b0 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_MSK, cntxt_src_ieob_irq_msk,
-    0x000120b8 + 0x4000 * GSI_EE_AP);
+    0x000120b8 + 0x4000 * DMA_EE_AP);
 
 REG(CNTXT_SRC_IEOB_IRQ_CLR, cntxt_src_ieob_irq_clr,
-    0x000120c0 + 0x4000 * GSI_EE_AP);
+    0x000120c0 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x00012100 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_STTS, cntxt_glob_irq_stts, 0x00012100 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x00012108 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_EN, cntxt_glob_irq_en, 0x00012108 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x00012110 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GLOB_IRQ_CLR, cntxt_glob_irq_clr, 0x00012110 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x00012118 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_STTS, cntxt_gsi_irq_stts, 0x00012118 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x00012120 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_EN, cntxt_gsi_irq_en, 0x00012120 + 0x4000 * DMA_EE_AP);
 
-REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x00012128 + 0x4000 * GSI_EE_AP);
+REG(CNTXT_GSI_IRQ_CLR, cntxt_gsi_irq_clr, 0x00012128 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_intset_fmask[] = {
 	[INTYPE]					= BIT(0)
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x00012180 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_INTSET, cntxt_intset, 0x00012180 + 0x4000 * DMA_EE_AP);
 
-REG_FIELDS(ERROR_LOG, error_log, 0x00012200 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(ERROR_LOG, error_log, 0x00012200 + 0x4000 * DMA_EE_AP);
 
-REG(ERROR_LOG_CLR, error_log_clr, 0x00012210 + 0x4000 * GSI_EE_AP);
+REG(ERROR_LOG_CLR, error_log_clr, 0x00012210 + 0x4000 * DMA_EE_AP);
 
 static const u32 reg_cntxt_scratch_0_fmask[] = {
 	[INTER_EE_RESULT]				= GENMASK(2, 0),
@@ -249,7 +249,7 @@ static const u32 reg_cntxt_scratch_0_fmask[] = {
 						/* Bits 8-31 reserved */
 };
 
-REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x00012400 + 0x4000 * GSI_EE_AP);
+REG_FIELDS(CNTXT_SCRATCH_0, cntxt_scratch_0, 0x00012400 + 0x4000 * DMA_EE_AP);
 
 static const struct reg *reg_array[] = {
 	[INTER_EE_SRC_CH_IRQ_MSK]	= &reg_inter_ee_src_ch_irq_msk,

--- a/drivers/net/ipa/reg/ipa_reg-v3.1.c
+++ b/drivers/net/ipa/reg/ipa_reg-v3.1.c
@@ -368,33 +368,33 @@ static const u32 reg_endp_filter_router_hsh_cfg_fmask[] = {
 REG_STRIDE_FIELDS(ENDP_FILTER_ROUTER_HSH_CFG, endp_filter_router_hsh_cfg,
 		  0x0000085c, 0x0070);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00003008 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00003008 + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_EN, ipa_irq_en, 0x0000300c + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_EN, ipa_irq_en, 0x0000300c + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00003010 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00003010 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ipa_irq_uc_fmask[] = {
 	[UC_INTR]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000301c + 0x1000 * GSI_EE_AP);
+REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000301c + 0x1000 * DMA_EE_AP);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_INFO, irq_suspend_info,
-	   0x00003030 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003030 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_EN, irq_suspend_en,
-	   0x00003034 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003034 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_CLR, irq_suspend_clr,
-	   0x00003038 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003038 + 0x1000 * DMA_EE_AP, 0x0004);
 
 static const struct reg *reg_array[] = {
 	[COMP_CFG]			= &reg_comp_cfg,

--- a/drivers/net/ipa/reg/ipa_reg-v3.5.1.c
+++ b/drivers/net/ipa/reg/ipa_reg-v3.5.1.c
@@ -379,33 +379,33 @@ static const u32 reg_endp_filter_router_hsh_cfg_fmask[] = {
 REG_STRIDE_FIELDS(ENDP_FILTER_ROUTER_HSH_CFG, endp_filter_router_hsh_cfg,
 		  0x0000085c, 0x0070);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00003008 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00003008 + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_EN, ipa_irq_en, 0x0000300c + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_EN, ipa_irq_en, 0x0000300c + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00003010 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00003010 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ipa_irq_uc_fmask[] = {
 	[UC_INTR]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000301c + 0x1000 * GSI_EE_AP);
+REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000301c + 0x1000 * DMA_EE_AP);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_INFO, irq_suspend_info,
-	   0x00003030 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003030 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_EN, irq_suspend_en,
-	   0x00003034 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003034 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_CLR, irq_suspend_clr,
-	   0x00003038 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003038 + 0x1000 * DMA_EE_AP, 0x0004);
 
 static const struct reg *reg_array[] = {
 	[COMP_CFG]			= &reg_comp_cfg,

--- a/drivers/net/ipa/reg/ipa_reg-v4.11.c
+++ b/drivers/net/ipa/reg/ipa_reg-v4.11.c
@@ -435,33 +435,33 @@ static const u32 reg_endp_filter_router_hsh_cfg_fmask[] = {
 REG_STRIDE_FIELDS(ENDP_FILTER_ROUTER_HSH_CFG, endp_filter_router_hsh_cfg,
 		  0x0000085c, 0x0070);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00004008 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00004008 + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_EN, ipa_irq_en, 0x0000400c + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_EN, ipa_irq_en, 0x0000400c + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00004010 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00004010 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ipa_irq_uc_fmask[] = {
 	[UC_INTR]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000401c + 0x1000 * GSI_EE_AP);
+REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000401c + 0x1000 * DMA_EE_AP);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_INFO, irq_suspend_info,
-	   0x00004030 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00004030 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_EN, irq_suspend_en,
-	   0x00004034 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00004034 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_CLR, irq_suspend_clr,
-	   0x00004038 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00004038 + 0x1000 * DMA_EE_AP, 0x0004);
 
 static const struct reg *reg_array[] = {
 	[COMP_CFG]			= &reg_comp_cfg,

--- a/drivers/net/ipa/reg/ipa_reg-v4.2.c
+++ b/drivers/net/ipa/reg/ipa_reg-v4.2.c
@@ -381,33 +381,33 @@ static const u32 reg_endp_status_fmask[] = {
 
 REG_STRIDE_FIELDS(ENDP_STATUS, endp_status, 0x00000840, 0x0070);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00003008 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00003008 + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_EN, ipa_irq_en, 0x0000300c + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_EN, ipa_irq_en, 0x0000300c + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00003010 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00003010 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ipa_irq_uc_fmask[] = {
 	[UC_INTR]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000301c + 0x1000 * GSI_EE_AP);
+REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000301c + 0x1000 * DMA_EE_AP);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_INFO, irq_suspend_info,
-	   0x00003030 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003030 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_EN, irq_suspend_en,
-	   0x00003034 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003034 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_CLR, irq_suspend_clr,
-	   0x00003038 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003038 + 0x1000 * DMA_EE_AP, 0x0004);
 
 static const struct reg *reg_array[] = {
 	[COMP_CFG]			= &reg_comp_cfg,

--- a/drivers/net/ipa/reg/ipa_reg-v4.5.c
+++ b/drivers/net/ipa/reg/ipa_reg-v4.5.c
@@ -454,33 +454,33 @@ static const u32 reg_endp_filter_router_hsh_cfg_fmask[] = {
 REG_STRIDE_FIELDS(ENDP_FILTER_ROUTER_HSH_CFG, endp_filter_router_hsh_cfg,
 		  0x0000085c, 0x0070);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00003008 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00003008 + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_EN, ipa_irq_en, 0x0000300c + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_EN, ipa_irq_en, 0x0000300c + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00003010 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00003010 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ipa_irq_uc_fmask[] = {
 	[UC_INTR]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000301c + 0x1000 * GSI_EE_AP);
+REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000301c + 0x1000 * DMA_EE_AP);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_INFO, irq_suspend_info,
-	   0x00003030 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003030 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_EN, irq_suspend_en,
-	   0x00003034 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003034 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_CLR, irq_suspend_clr,
-	   0x00003038 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003038 + 0x1000 * DMA_EE_AP, 0x0004);
 
 static const struct reg *reg_array[] = {
 	[COMP_CFG]			= &reg_comp_cfg,

--- a/drivers/net/ipa/reg/ipa_reg-v4.7.c
+++ b/drivers/net/ipa/reg/ipa_reg-v4.7.c
@@ -427,33 +427,33 @@ static const u32 reg_endp_filter_router_hsh_cfg_fmask[] = {
 REG_STRIDE_FIELDS(ENDP_FILTER_ROUTER_HSH_CFG, endp_filter_router_hsh_cfg,
 		  0x0000085c, 0x0070);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00003008 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00003008 + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_EN, ipa_irq_en, 0x0000300c + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_EN, ipa_irq_en, 0x0000300c + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00003010 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00003010 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ipa_irq_uc_fmask[] = {
 	[UC_INTR]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000301c + 0x1000 * GSI_EE_AP);
+REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000301c + 0x1000 * DMA_EE_AP);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_INFO, irq_suspend_info,
-	   0x00003030 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003030 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_EN, irq_suspend_en,
-	   0x00003034 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003034 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_CLR, irq_suspend_clr,
-	   0x00003038 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00003038 + 0x1000 * DMA_EE_AP, 0x0004);
 
 static const struct reg *reg_array[] = {
 	[COMP_CFG]			= &reg_comp_cfg,

--- a/drivers/net/ipa/reg/ipa_reg-v4.9.c
+++ b/drivers/net/ipa/reg/ipa_reg-v4.9.c
@@ -432,33 +432,33 @@ static const u32 reg_endp_filter_router_hsh_cfg_fmask[] = {
 REG_STRIDE_FIELDS(ENDP_FILTER_ROUTER_HSH_CFG, endp_filter_router_hsh_cfg,
 		  0x0000085c, 0x0070);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00004008 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_STTS, ipa_irq_stts, 0x00004008 + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_EN, ipa_irq_en, 0x0000400c + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_EN, ipa_irq_en, 0x0000400c + 0x1000 * DMA_EE_AP);
 
-/* Valid bits defined by enum ipa_irq_id; only used for GSI_EE_AP */
-REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00004010 + 0x1000 * GSI_EE_AP);
+/* Valid bits defined by enum ipa_irq_id; only used for DMA_EE_AP */
+REG(IPA_IRQ_CLR, ipa_irq_clr, 0x00004010 + 0x1000 * DMA_EE_AP);
 
 static const u32 reg_ipa_irq_uc_fmask[] = {
 	[UC_INTR]					= BIT(0),
 						/* Bits 1-31 reserved */
 };
 
-REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000401c + 0x1000 * GSI_EE_AP);
+REG_FIELDS(IPA_IRQ_UC, ipa_irq_uc, 0x0000401c + 0x1000 * DMA_EE_AP);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_INFO, irq_suspend_info,
-	   0x00004030 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00004030 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_EN, irq_suspend_en,
-	   0x00004034 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00004034 + 0x1000 * DMA_EE_AP, 0x0004);
 
 /* Valid bits defined by ipa->available */
 REG_STRIDE(IRQ_SUSPEND_CLR, irq_suspend_clr,
-	   0x00004038 + 0x1000 * GSI_EE_AP, 0x0004);
+	   0x00004038 + 0x1000 * DMA_EE_AP, 0x0004);
 
 static const struct reg *reg_array[] = {
 	[COMP_CFG]			= &reg_comp_cfg,

--- a/include/linux/dmaengine.h
+++ b/include/linux/dmaengine.h
@@ -190,6 +190,9 @@ struct dma_interleaved_template {
  *  transaction is marked with DMA_PREP_REPEAT will cause the new transaction
  *  to never be processed and stay in the issued queue forever. The flag is
  *  ignored if the previous transaction is not a repeated transaction.
+ *  @DMA_PREP_IMM_CMD: tell the driver that the data passed to the DMA API is
+ *  immediate command data and the descriptor should be in a different format
+ *  from the normal data and descriptor
  */
 enum dma_ctrl_flags {
 	DMA_PREP_INTERRUPT = (1 << 0),
@@ -202,6 +205,7 @@ enum dma_ctrl_flags {
 	DMA_PREP_CMD = (1 << 7),
 	DMA_PREP_REPEAT = (1 << 8),
 	DMA_PREP_LOAD_EOT = (1 << 9),
+	DMA_PREP_IMM_CMD = (1 << 10),
 };
 
 /**


### PR DESCRIPTION
/Here are the patches for IPA v2 rebased to branch 6.3.0/ipa (starting from commit  dbfb5bd9330eeba18015dc821f885163813c0058) (created with git format-patch):
[0001-Initial-port-of-the-IPAv2-driver-from-6.1.0-to-6.3.0.patch.txt](https://github.com/msm8916-mainline/linux/files/11472015/0001-Initial-port-of-the-IPAv2-driver-from-6.1.0-to-6.3.0.patch.txt)
[0002-Next-part-of-the-IPA-v2-commit.patch.txt](https://github.com/msm8916-mainline/linux/files/11472017/0002-Next-part-of-the-IPA-v2-commit.patch.txt)
[0003-Next-commit-of-the-IPA-v2-port-there-are-still-issue.patch.txt](https://github.com/msm8916-mainline/linux/files/11472019/0003-Next-commit-of-the-IPA-v2-port-there-are-still-issue.patch.txt)
[0004-Fixed-the-issues-with-the-entry-size-by-reintroducin.patch.txt](https://github.com/msm8916-mainline/linux/files/11472020/0004-Fixed-the-issues-with-the-entry-size-by-reintroducin.patch.txt)
[0005-Rest-of-the-port-of-IPA-v2-and-compile-fixes-of-the-.patch.txt](https://github.com/msm8916-mainline/linux/files/11472026/0005-Rest-of-the-port-of-IPA-v2-and-compile-fixes-of-the-.patch.txt)
[0006-Add-devicetree-support-for-ipa-and-ipa_bam-and-enabl.patch.txt](https://github.com/msm8916-mainline/linux/files/11472027/0006-Add-devicetree-support-for-ipa-and-ipa_bam-and-enabl.patch.txt)
[0007-Rename-header-file.patch.txt](https://github.com/msm8916-mainline/linux/files/11472028/0007-Rename-header-file.patch.txt)
[0008-Add-modem_route_count-to-IPA-v2-data.patch.txt](https://github.com/msm8916-mainline/linux/files/11472030/0008-Add-modem_route_count-to-IPA-v2-data.patch.txt)
[0009-Added-filter_support-true-to-two-channels-to-stop-IP.patch.txt](https://github.com/msm8916-mainline/linux/files/11472031/0009-Added-filter_support-true-to-two-channels-to-stop-IP.patch.txt)
[0010-This-bit-in-the-ROUTE-register-exists-only-for-IPA-v.patch.txt](https://github.com/msm8916-mainline/linux/files/11472032/0010-This-bit-in-the-ROUTE-register-exists-only-for-IPA-v.patch.txt)
This does not belong here but I have it in my branch to avoid the cache errors
[0011-Add-i-d-cache-size-properties-to-the-CPU-nodes-cache.patch.txt](https://github.com/msm8916-mainline/linux/files/11472035/0011-Add-i-d-cache-size-properties-to-the-CPU-nodes-cache.patch.txt)
[0012-ipa_firmware_loader-can-handle-the-IPA-v2-case-witho.patch.txt](https://github.com/msm8916-mainline/linux/files/11472037/0012-ipa_firmware_loader-can-handle-the-IPA-v2-case-witho.patch.txt)
These patches seem to initialize IPA v2 correctly on a fairphone-fp3 (running standard debian sid). There are still some issues appearing in dmesg (venus clk getting stuck at off, pclk0_clk_src: rcg didn't update its configuration.
) but these may have other causes.
This patch fixes a hang on shutdown, that occured because IPA v2 does not have hashed tables.
[0013-Hashed-tables-are-only-present-on-IPA-v3.patch.txt](https://github.com/msm8953-mainline/linux/files/11472176/0013-Hashed-tables-are-only-present-on-IPA-v3.patch.txt)

