### PR TITLE
arm64: dts: qcom: xiaomi-vince: enable modem and mdss

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
@@ -124,6 +124,14 @@
 	voltage-max-design-microvolt = <4380000>;
 };
 
+&mdss {
+	status = "okay";
+};
+
+&modem {
+	status = "okay";
+};
+
 &panel {
 	compatible = "xiaomi,vince-panel";
 };


### PR DESCRIPTION
I tested modem with (don't have sim available right now):
```
xiaomi-vince:~$ qmicli -d qrtr://0 --dms-get-manufacturer
[qrtr://0] Device manufacturer retrieved:
        Manufacturer: 'QUALCOMM INCORPORATED'
xiaomi-vince:~$ qmicli -d qrtr://0 --dms-get-software-version
[qrtr://0] Software version: 953_GEN_PACK-1.174284.1.194887.2
xiaomi-vince:~$ qmicli -d qrtr://0 --dms-get-revision
[qrtr://0] Device revision retrieved:
        Revision: 'MPSS.TA.2.3.c1-00696-8953_GEN_PACK-1.174284.1.194887.2  1  [Mar 13 2019 01:00:00]'
xiaomi-vince:~$ qmicli -d qrtr://0 --dms-get-capabilities
[qrtr://0] Device capabilities retrieved:
        Max TX channel rate: '50000000'
        Max RX channel rate: '100000000'
               Data Service: 'non-simultaneous-cs-ps'
                        SIM: 'supported'
                   Networks: 'cdma20001x, evdo, gsm, umts, lte, tds'
xiaomi-vince:~$ qmicli -d qrtr://0 --dms-get-ids
[qrtr://0] Device IDs retrieved:
            ESN: '80'
           IMEI: 'VALID_IMEI'
           MEID: 'VALID_MEID'
        IMEI SV: '1'
```

and 
/sys/devices/platform/soc@0/1a00000.display-subsystem/ seems to exists and populated