### PR TITLE
arm64: dts: qcom: msm8953: xiaomi-mido: add battery info

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
@@ -86,6 +86,13 @@
 	};
 };
 
+&battery {
+	charge-full-design-microamp-hours = <4100000>;
+	constant-charge-current-max-microamp = <1000000>;
+	voltage-min-design-microvolt = <3400000>;
+	voltage-max-design-microvolt = <4400000>;
+};
+
 &ft5406_ts {
 	status = "okay";
 


### PR DESCRIPTION
Add battery node for mido it enable charging and fix usb networking.