### PR TITLE
arm64: dts: qcom: msm8953: xiaomi-vince: enable soundcard

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
@@ -144,6 +144,16 @@
 	status = "okay";
 };
 
+&sound_card {
+	model = "xiaomi-vince";
+
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&cdc_pdm_lines_act &cdc_pdm_lines_2_act &cdc_pdm_comp_lines_act &pri_tlmm_default>;
+	pinctrl-1 = <&cdc_pdm_lines_sus &cdc_pdm_lines_2_sus &cdc_pdm_comp_lines_sus &pri_tlmm_default>;
+	
+	status = "okay";
+};
+
 &tlmm {
 	gpio-reserved-ranges = <0 4>, <16 4>, <135 4>;
 
@@ -152,6 +162,13 @@
 		function = "gpio";
 		drive-strength = <2>;
 		bias-pull-up;
+	};
+
+	pri_tlmm_default: pri-tlmm-pins {
+		pins = "gpio88", "gpio91", "gpio93";
+		function = "pri_mi2s";
+		drive-strength = <8>;
+		bias-disable;
 	};
 };
 


### PR DESCRIPTION
Here I also attach a working ucm2 profile for vince soundcard.
I will add it to device-xiaomi-vince package.

Tested and working with jack-sensing and media buttons (play/pause from headphones).
Tested and working playback/recording, both with prim and sec mics and with headphones mic

Only 3 notable things:
- it generate a background noise when there's no output signal
- start from a low-level volume. the output is very loud

UCM2:
https://github.com/M0Rf30/msm8953-snd-card-mtp/tree/6.3.0

This UCM can be adapted or generalized to work on all devices without speaker and CS-Voice support
