### PR TITLE
xiaomi-mido: enable soundcard

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
@@ -108,8 +108,30 @@
 	cd-gpios = <&tlmm 133 GPIO_ACTIVE_LOW>;
 };
 
+&sound_card {
+
+	model = "xiaomi-mido";
+
+	aux-devs = <&speaker_amp>;
+	audio-routing =
+		"AMIC1", "MIC BIAS External1",
+		"AMIC2", "MIC BIAS Internal2",
+		"AMIC3", "MIC BIAS External1";
+
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&cdc_pdm_lines_act &cdc_pdm_lines_2_act &cdc_pdm_comp_lines_act>;
+	pinctrl-1 = <&cdc_pdm_lines_sus &cdc_pdm_lines_2_sus &cdc_pdm_comp_lines_sus>;
+
+	status = "okay";
+};
+
 &tlmm {
 	gpio-reserved-ranges = <0 4>, <135 4>;
+};
+
+&wcd_codec {
+	/delete-property/ qcom,gnd-jack-type-normally-open;
+	/delete-property/ qcom,hphl-jack-type-normally-open;
 };
 
 &wcnss {


### PR DESCRIPTION
I have enabled sound_card node for mido with proper ucm (modified vince) config almost everything is working.
(speaker, earpiece, mics, headphones, headsetmic, headset control)

[HiFi.conf](https://gist.github.com/barni2000/e8b6bcfb3e1642526f2d0e137d59569c)
[Forked msm8916-mainline/alsa-ucm-conf](https://github.com/barni2000/alsa-ucm-conf)

It also work with original mido HiFi.conf but /usr/share/alsa/ucm2/platforms/msm8916/qdsp6.conf should be modified, CS-Voice lines should be commented out.

In mido HiFi.conf
``` cset "name='RX3 Digital Volume' 115"``` should be modified to ``` cset "name='RX3 Digital Volume' 78"```
