### PR TITLE
xiaomi-ysl: enable soundcard

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-ysl.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-ysl.dts
@@ -13,6 +13,13 @@
 	compatible = "xiaomi,ysl", "qcom,msm8953";
 	qcom,board-id = <8 0>;
 
+	speaker_amp: audio-amplifier {
+		compatible = "awinic,aw8738";
+		mode-gpios = <&tlmm 139 GPIO_ACTIVE_HIGH>;
+		awinic,mode = <5>;
+		sound-name-prefix = "Speaker Amp";
+	};
+
 	chosen {
 		#address-cells = <2>;
 		#size-cells = <2>;
@@ -122,6 +129,26 @@
 
 &sdhc_2 {
 	cd-gpios = <&tlmm 133 GPIO_ACTIVE_HIGH>;
+};
+
+&sound_card {
+	model = "xiaomi-ysl";
+
+	aux-devs = <&speaker_amp>;
+	audio-routing =
+		"AMIC1", "MIC BIAS External1",
+		"AMIC2", "MIC BIAS External2",
+		"AMIC3", "MIC BIAS External1";
+
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&cdc_pdm_lines_act &cdc_pdm_lines_2_act &cdc_pdm_comp_lines_act>;
+	pinctrl-1 = <&cdc_pdm_lines_sus &cdc_pdm_lines_2_sus &cdc_pdm_comp_lines_sus>;
+
+	status = "okay";
+};
+
+&wcd_codec {
+	qcom,micbias2-ext-cap;
 };
 
 &tlmm {


### PR DESCRIPTION
I have enabled sound_card node for ysl with proper ucm (modified vince) config almost everything is working. It works with mido config.
(speaker, earpiece, mics, headphones, headsetmic)

[HiFi.conf](https://gist.github.com/barni2000/e8b6bcfb3e1642526f2d0e137d59569c)
[Forked msm8916-mainline/alsa-ucm-conf](https://github.com/barni2000/alsa-ucm-conf)

It also work with original mido HiFi.conf but /usr/share/alsa/ucm2/platforms/msm8916/qdsp6.conf should be modified, CS-Voice lines should be commented out.

In mido HiFi.conf
``` cset "name='RX3 Digital Volume' 115"``` should be modified to ``` cset "name='RX3 Digital Volume' 78"```

