### PR TITLE
arm64: dts: qcom: xiaomi-tissot: Add simple-amplifier for headphones

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-tissot.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-tissot.dts
@@ -21,6 +21,16 @@
 	compatible = "xiaomi,tissot", "qcom,msm8953";
 	qcom,board-id = <0x1000b 0x00>;
 
+	headphones_amp: analog-amplifier {
+		compatible = "simple-audio-amplifier";
+		enable-gpios = <&tlmm 141 GPIO_ACTIVE_HIGH>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&headphones_amp_default>;
+
+		sound-name-prefix = "Headphones Amp";
+	};
+
 	chosen {
 		#address-cells = <2>;
 		#size-cells = <2>;
@@ -177,12 +187,17 @@
 &sound_card {
 	status = "okay";
 
-	/* xiaomi-tissot sound configuration is similar to xiaomi-daisy */
-	model = "xiaomi-daisy";
+	model = "xiaomi-tissot";
 
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&cdc_pdm_lines_act &cdc_pdm_lines_2_act &cdc_pdm_comp_lines_act &pri_tlmm_default>;
 	pinctrl-1 = <&cdc_pdm_lines_sus &cdc_pdm_lines_2_sus &cdc_pdm_comp_lines_sus &pri_tlmm_default>;
+
+	aux-devs = <&headphones_amp>;
+	audio-routing =
+		"AMIC1", "MIC BIAS External1",
+		"AMIC2", "MIC BIAS Internal2",
+		"AMIC3", "MIC BIAS External1";
 
 	quinary-mi2s-dai-link {
 		link-name = "Quinary MI2S";
@@ -215,6 +230,14 @@
 		function = "pri_mi2s";
 		drive-strength = <8>;
 		bias-disable;
+	};
+
+	headphones_amp_default: headphones-switch-default-state {
+		pins = "gpio141";
+		function = "gpio";
+		drive-strength = <16>;
+		bias-disable;
+		output-low;
 	};
 };
 


### PR DESCRIPTION
xiaomi-tissot is using external max97220 amplifier for headphones.
This PR define simple-amplifier node for utilize the amplifier.

Other small changes:
- audio-routing
- set back model to xiaomi-tissot