### PR TITLE
xiaomi-mido: set proper voltage-max-design-microvolt

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
@@ -90,7 +90,7 @@
 	charge-full-design-microamp-hours = <4100000>;
 	constant-charge-current-max-microamp = <1000000>;
 	voltage-min-design-microvolt = <3400000>;
-	voltage-max-design-microvolt = <4400000>;
+	voltage-max-design-microvolt = <4380000>;
 };
 
 &ft5406_ts {


### PR DESCRIPTION
The voltage-max-design-microvolt was incorrectly setted to 4400000. I have corrected to 4380000.
```
POWER_SUPPLY_VOLTAGE_MAX_DESIGN=4380000
```