### PR TITLE
Clean ups and fixes for mido, ysl, tissot

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
@@ -133,16 +133,3 @@
 	/delete-property/ qcom,gnd-jack-type-normally-open;
 	/delete-property/ qcom,hphl-jack-type-normally-open;
 };
-
-&wcnss {
-	status = "okay";
-
-	vddpx-supply = <&pm8953_l5>;
-};
-
-&wcnss_iris {
-	vddxo-supply = <&pm8953_l7>;
-	vddrfa-supply = <&pm8953_l19>;
-	vddpa-supply = <&pm8953_l9>;
-	vdddig-supply = <&pm8953_l5>;
-};

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-tissot.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-tissot.dts
@@ -267,6 +267,6 @@
 	status = "okay";
 };
 
-&panel {
-	compatible = "xiaomi,tissot-panel";
+&wcnss_iris {
+	compatible = "qcom,wcn3680";
 };

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-ysl.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-ysl.dts
@@ -13,6 +13,11 @@
 	compatible = "xiaomi,ysl", "qcom,msm8953";
 	qcom,board-id = <8 0>;
 
+	aliases {
+		mmc0 = &sdhc_1;
+		mmc1 = &sdhc_2;
+	};
+
 	speaker_amp: audio-amplifier {
 		compatible = "awinic,aw8738";
 		mode-gpios = <&tlmm 139 GPIO_ACTIVE_HIGH>;
@@ -66,12 +71,6 @@
 			reg = <0x0 0x90001000 0x0 (720 * 1440 * 3)>;
 			no-map;
 		};
-
-		ramoops@9ff00000 {
-			compatible = "ramoops";
-			reg = <0x0 0x9ff00000 0x0 0x00100000>;
-			console-size = <0x100000>;
-		};
 	};
 
 	i2c-gpio {
@@ -98,10 +97,6 @@
 
 &aw2013_led {
 	status = "okay";
-
-	led@0 {
-		color = <LED_COLOR_ID_RED>;
-	};
 };
 
 &battery {
@@ -125,6 +120,15 @@
 
 &panel {
 	compatible = "xiaomi,ysl-panel";
+};
+
+&pm8953_l6 {
+	regulator-always-on;
+};
+
+&pm8953_l10 {
+	regulator-min-microvolt = <2800000>;
+	regulator-always-on;
 };
 
 &sdhc_2 {


### PR DESCRIPTION
Ysl:
- I have corrected the regulators like in downstream
https://github.com/MiCode/Xiaomi_Kernel_OpenSource/commit/09f6450330b57b8df8b4472917c2d71adc0386d4#diff-1d92316904c11eef1f77aa098cc2b3c418bf8ff1e1fcb7f9fef834f3b8ef0b2eL219-R228
- Added aliases for sdhc_1 and sdhc_2
- I have removed ramoops because it was mapped for wrong address and the address from downstream is overlapping with venus_mem
- I have removed led@0 definition common already define it and device has white led

Mido:
- I have removed wcnss related nodes they are already defined in the msm8953-xiaomi-common

Tissot:
- I have removed duplicated panel nodes
- wcnss_iris has been set to qcom,wcn3680 tissot has 3680b