### PR TITLE
Add Goodix GT917D touchscreen support for Xiaomi Daisy 

### DIFF
--- a/Documentation/devicetree/bindings/input/touchscreen/goodix.yaml
+++ b/Documentation/devicetree/bindings/input/touchscreen/goodix.yaml
@@ -23,6 +23,7 @@ properties:
       - goodix,gt9110
       - goodix,gt912
       - goodix,gt9147
+      - goodix,gt917d
       - goodix,gt917s
       - goodix,gt927
       - goodix,gt9271

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-common.dtsi
@@ -169,6 +169,24 @@
 
 		status = "disabled";
 	};
+
+	gt917d_ts: touchscreen@5d {
+		compatible = "goodix,gt917d";
+		reg = <0x5d>;
+
+		interrupt-parent = <&tlmm>;
+		interrupts = <65 IRQ_TYPE_EDGE_FALLING>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&ts_int_default>;
+
+		reset-gpios = <&tlmm 64 GPIO_ACTIVE_HIGH>;
+
+		VDDIO-supply = <&pm8953_l6>;
+		AVDD28-supply = <&pm8953_l10>;
+
+		status = "disabled";
+	};
 };
 
 &lpass {
@@ -354,6 +372,14 @@
 		function = "gpio";
 		drive-strength = <8>;
 		bias-pull-up;
+	};
+
+	ts_int_default: ts-int-default {
+		pins = "gpio65";
+		function = "gpio";
+		drive-strength = <16>;
+		input-enable;
+		bias-disable;
 	};
 
 	ts_int_suspend: ts-int-suspend-state {

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
@@ -101,6 +101,13 @@
 	touchscreen-size-y = <2280>;
 };
 
+&gt917d_ts {
+	status = "okay";
+
+	touchscreen-size-x = <1080>;
+	touchscreen-size-y = <2280>;
+};
+
 &panel {
 	compatible = "xiaomi,daisy-panel";
 };

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
@@ -95,14 +95,14 @@
 };
 
 &ft5406_ts {
-	status = "okay";
+	status = "disabled";
 
 	touchscreen-size-x = <1080>;
 	touchscreen-size-y = <2280>;
 };
 
 &gt917d_ts {
-	status = "okay";
+	status = "disabled";
 
 	touchscreen-size-x = <1080>;
 	touchscreen-size-y = <2280>;

--- a/drivers/input/touchscreen/goodix.c
+++ b/drivers/input/touchscreen/goodix.c
@@ -110,7 +110,9 @@ static const struct goodix_chip_id goodix_chip_ids[] = {
 
 	{ .id = "912", .data = &gt967_chip_data },
 	{ .id = "9147", .data = &gt967_chip_data },
+	{ .id = "917D", .data = &gt967_chip_data },
 	{ .id = "967", .data = &gt967_chip_data },
+
 	{ }
 };
 
@@ -1534,6 +1536,7 @@ static const struct of_device_id goodix_of_match[] = {
 	{ .compatible = "goodix,gt9110" },
 	{ .compatible = "goodix,gt912" },
 	{ .compatible = "goodix,gt9147" },
+	{ .compatible = "goodix,gt917d" },
 	{ .compatible = "goodix,gt917s" },
 	{ .compatible = "goodix,gt927" },
 	{ .compatible = "goodix,gt9271" },


### PR DESCRIPTION
Depends on https://github.com/msm8953-mainline/lk2nd/pull/57 for enabling the correct touchscreen according to the display.

Fixes #33 