### PR TITLE
fixup! arm64: dts: qcom: Commonize msm8953-xiaomi trees

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-common.dtsi
@@ -89,7 +89,7 @@
 
 		vmon-slot-no = <1>;
 		imon-slot-no = <1>;
-		interleave_mode = <0>;
+		maxim,interleave-mode;
 
 		#sound-dai-cells = <0>;
 	};
@@ -120,7 +120,6 @@
 	rmi4_ts: touchscreen@20 {
 		reg = <0x20>;
 		compatible = "syna,rmi4-i2c";
-		interrupts-parent = <&tlmm>;
 		interrupts-extended = <&tlmm 65 IRQ_TYPE_EDGE_FALLING>;
 
 		#address-cells = <1>;


### PR DESCRIPTION
This integrate the following changes on the commonized device tree:

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/arch/arm64/boot/dts/qcom?h=v6.6-rc1&id=b6866546c214aad707f69a7d96215e3d08c2eb84
```
arm64: dts: qcom: msm8953-daisy: use new speaker maxim,interleave-mode
MAX98927 speaker amplifier "interleave_mode" property was never
documented.  Corrected bindings expect "maxim,interleave-mode" instead,
which is already supported by Linux driver.  Change is not compatible
with older Linux kernels.

Signed-off-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
Link: https://lore.kernel.org/r/20230730202051.71099-1-krzysztof.kozlowski@linaro.org
Signed-off-by: Bjorn Andersson <andersson@kernel.org>

```


https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/arch/arm64/boot/dts/qcom?h=v6.6-rc1&id=b019cf7e5fbaa7d25f716cb936a9237b47156f2d
```
arm64: dts: qcom: msm8953-vince: drop duplicated touschreen parent interrupt
Interrupts extended already define a parent interrupt controller:

  msm8953-xiaomi-vince.dtb: touchscreen@20: Unevaluated properties are not allowed ('interrupts-parent' was unexpected)

Fixes: aa17e707e04a ("arm64: dts: qcom: msm8953: Add device tree for Xiaomi Redmi 5 Plus")
Cc: <stable@vger.kernel.org>
Signed-off-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
Reviewed-by: Konrad Dybcio <konrad.dybcio@linaro.org>
Link: https://lore.kernel.org/r/20230720115335.137354-1-krzysztof.kozlowski@linaro.org
Signed-off-by: Bjorn Andersson <andersson@kernel.org>
```

