### PR TITLE
HACK arm64: dts: qcom: msm8953-xiaom-tissot: remove power-domains from gcc node

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-tissot.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-tissot.dts
@@ -158,6 +158,12 @@
 	touchscreen-size-y = <1920>;
 };
 
+&gcc {
+	/* HACK: This helps for tissot to boot, */
+	/* it should be removed when proper fix is landed. */
+	/delete-property/ power-domains;
+};
+
 &max98927_codec {
 	status = "okay";
 


### PR DESCRIPTION
This hack helps tissot to boot without this tissot will stuck at boot in most cases, it should be removed after we find a proper fix.