### PR TITLE
Fix panel and wifi on Fairphone 3

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm632-fairphone-fp3.dts
+++ b/arch/arm64/boot/dts/qcom/sdm632-fairphone-fp3.dts
@@ -312,6 +312,8 @@
 };
 
 &wcnss_iris {
+	compatible = "qcom,wcn3660b"; /* WCN3680B */
+
 	vddxo-supply = <&pm8953_l7>;
 	vddrfa-supply = <&pm8953_l19>;
 	vddpa-supply = <&pm8953_l9>;

--- a/arch/arm64/boot/dts/qcom/sdm632-fairphone-fp3.dts
+++ b/arch/arm64/boot/dts/qcom/sdm632-fairphone-fp3.dts
@@ -56,6 +56,9 @@
 
 		reset-gpios = <&tlmm 61 GPIO_ACTIVE_LOW>;
 
+		pinctrl-0 = <&mdss_te_default>;
+		pinctrl-names = "default";
+
 		// Downstream:
 		// lab-supply = <&lcdb_ldo_vreg>;
 		// ibb-supply = <&lcdb_ncp_vreg>;

--- a/drivers/gpu/drm/panel/msm8953-generated/panel-fairphone-fp3-hx83112b.c
+++ b/drivers/gpu/drm/panel/msm8953-generated/panel-fairphone-fp3-hx83112b.c
@@ -209,6 +209,12 @@ static int djn_hx83112b_on(struct djn_hx83112b *ctx)
 
 	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_CONTROL_DISPLAY, 0x24);
 
+	ret = mipi_dsi_dcs_set_tear_on(ctx->dsi, MIPI_DSI_DCS_TEAR_MODE_VBLANK);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set tear on: %d\n", ret);
+		return ret;
+	}
+
 	return 0;
 }
 

--- a/drivers/gpu/drm/panel/msm8953-generated/panel-fairphone-fp3-hx83112b.c
+++ b/drivers/gpu/drm/panel/msm8953-generated/panel-fairphone-fp3-hx83112b.c
@@ -392,6 +392,7 @@ static int djn_hx83112b_probe(struct mipi_dsi_device *dsi)
 
 	drm_panel_init(&ctx->panel, dev, &djn_hx83112b_panel_funcs,
 		       DRM_MODE_CONNECTOR_DSI);
+	ctx->panel.prepare_prev_first = true;
 
 	ctx->panel.backlight = djn_hx83112b_create_backlight(dsi);
 	if (IS_ERR(ctx->panel.backlight))


### PR DESCRIPTION
Two problems resolved:
* Set `prepare_prev_first` flag to fix display init (regression from 6.4, this flag is needed since 6.5)
* Finally resolve panel being stuck on 30Hz, TE signal was not working

And set the iris compatible to fix wifi/bt