### PR TITLE
Add initial camera support for mido and vince

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
@@ -63,7 +63,9 @@
 		ramoops@9ff00000 {
 			compatible = "ramoops";
 			reg = <0x0 0x9ff00000 0x0 0x00100000>;
+			record-size = <0x100000>;
 			console-size = <0x100000>;
+			pmsg-size = <0x100000>;
 		};
 	};
 };
@@ -91,6 +93,60 @@
 	constant-charge-current-max-microamp = <1000000>;
 	voltage-min-design-microvolt = <3400000>;
 	voltage-max-design-microvolt = <4380000>;
+};
+
+&cci {
+	pinctrl-names = "default";
+	pinctrl-0 = <&cci0_default>,
+		    <&cci1_default>,
+		    <&camss_mclk0_default>,
+		    <&camss_mclk1_default>;
+
+	status = "okay";
+};
+
+&cci_i2c0 {
+	camera-sensor@10 { // Primary rear camera
+		compatible = "samsung,s5k3l8";
+
+		reg = <0x10>;
+
+		clocks = <&gcc GCC_CAMSS_MCLK0_CLK>;
+		clock-frequency = <19200000>;
+
+		reset-gpios = <&tlmm 40 GPIO_ACTIVE_LOW>;
+
+		avdd-supply= <&pm8953_l22>;
+		dvdd-supply = <&pm8953_l2>;
+		vio-supply = <&pm8953_l6>;
+		aux-supply = <&pm8953_l17>;
+		status = "okay";
+
+		orientation = <1>;
+
+		port {
+			rear_cam_ep: endpoint {
+				data-lanes = <0 1 2 3>;
+				remote-endpoint = <&csiphy0_ep>;
+			};
+		};
+	};
+};
+
+&camss {
+	status = "okay";
+	vdda-supply = <&pm8953_s3>;
+
+	ports {
+		port@0 {
+			reg = <0>;
+			csiphy0_ep: endpoint {
+				clock-lanes = <7>;
+				data-lanes = <0 1 2 3>;
+				remote-endpoint = <&rear_cam_ep>;
+			};
+		};
+	};
 };
 
 &ft5406_ts {

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
@@ -124,8 +124,70 @@
 	voltage-max-design-microvolt = <4380000>;
 };
 
+&cci {
+	pinctrl-names = "default";
+	pinctrl-0 = <&cci0_default>,
+		    <&cci1_default>,
+		    <&camss_mclk0_default>,
+		    <&camss_mclk1_default>;
+
+	status = "okay";
+};
+
+&cci_i2c1 {
+	camera-sensor@36 { // Front camera
+		compatible = "ovti,ov5675";
+
+		reg = <0x36>;
+
+		clocks = <&gcc GCC_CAMSS_MCLK1_CLK>;
+		clock-rates = <24000000>;
+
+		pinctrl-0 = <&cam_sensor_front_default>;
+		pinctrl-names = "default";
+
+		reset-gpios = <&tlmm 129 GPIO_ACTIVE_LOW>;
+
+		avdd-supply= <&pm8953_l22>;
+		dvdd-supply = <&pm8953_l23>;
+		dovdd-supply = <&pm8953_l6>;
+		orientation = <0>;
+    rotation = <270>;
+
+    status = "okay";
+
+		port {
+			front_cam_ep: endpoint {
+				data-lanes = <0 1>;
+				remote-endpoint = <&csiphy2_ep>;
+				link-frequencies = /bits/ 64 <450000000>;
+			};
+		};
+	};
+};
+
+&camss {
+	status = "okay";
+	vdda-supply = <&pm8953_s3>;
+
+	ports {
+		port@2 {
+			reg = <2>;
+			csiphy2_ep: endpoint {
+				clock-lanes = <7>;
+				data-lanes = <0 1>;
+				remote-endpoint = <&front_cam_ep>;
+			};
+		};
+	};
+};
+
 &panel {
 	compatible = "xiaomi,vince-panel";
+};
+
+&pm8953_l23 {
+	regulator-min-microvolt = <1200000>;
 };
 
 &pmi8950_wled {
@@ -159,6 +221,13 @@
 
 &tlmm {
 	gpio-reserved-ranges = <0 4>, <16 4>, <135 4>;
+
+	cam_sensor_front_default: cam_sensor_front_default {
+		pins = "gpio129";
+		function = "gpio";
+		bias-disable;
+		drive-strength = <2>;
+	};
 
 	gpio_hall_sensor_default: gpio-hall-sensor-state {
 		pins = "gpio44";

--- a/drivers/media/i2c/s5k2xx.c
+++ b/drivers/media/i2c/s5k2xx.c
@@ -16,6 +16,7 @@
 #include <media/v4l2-fwnode.h>
 
 #define S5K2XX_MCLK			24000000
+#define S5K3L8_MCLK			19200000
 #define S5K2XX_DATA_LANES		4
 #define S5K2XX_MAX_COLOR_DEPTH		10
 #define S5K2XX_MAX_COLOR_VAL		(BIT(S5K2XX_MAX_COLOR_DEPTH) - 1)
@@ -118,6 +119,7 @@ struct s5k2xx_data {
 	const struct s5k2xx_mode *modes;
 	size_t num_modes;
 	const struct reg_sequence *init_regs;
+	const u32 mclk;
 	u32 num_init_regs;
 };
 
@@ -251,6 +253,7 @@ static struct s5k2xx_data s5k2p6sx_data = {
 	.num_modes = ARRAY_SIZE(s5k2p6_modes),
 	.init_regs = s5k2p6_init,
 	.num_init_regs = ARRAY_SIZE(s5k2p6_init),
+	.mclk = S5K2XX_MCLK,
 };
 
 static const struct reg_sequence s5k2x7_init[] = {
@@ -561,6 +564,7 @@ static struct s5k2xx_data s5k2x7sp_data = {
 	.num_modes = ARRAY_SIZE(s5k2x7_modes),
 	.init_regs = s5k2x7_init,
 	.num_init_regs = ARRAY_SIZE(s5k2x7_init),
+	.mclk = S5K2XX_MCLK,
 };
 
 static const struct reg_sequence s5k3l8_init[] = {
@@ -703,6 +707,7 @@ static struct s5k2xx_data s5k3l8_data = {
 	.num_modes = ARRAY_SIZE(s5k3l8_modes),
 	.init_regs = s5k3l8_init,
 	.num_init_regs = ARRAY_SIZE(s5k3l8_init),
+	.mclk = S5K3L8_MCLK,
 };
 
 struct s5k2xx {
@@ -1057,7 +1062,7 @@ static int s5k2xx_power_on(struct device *dev)
 	}
 
 	if (s5k2xx->mclk) {
-		ret = clk_set_rate(s5k2xx->mclk, S5K2XX_MCLK);
+		ret = clk_set_rate(s5k2xx->mclk, s5k2xx->data->mclk);
 		if (ret) {
 			dev_err(dev, "can't set clock frequency");
 			return ret;
@@ -1283,7 +1288,7 @@ static int s5k2xx_check_hwcfg(struct s5k2xx *s5k2xx, struct device *dev)
 		return ret;
 	}
 
-	if (mclk != S5K2XX_MCLK) {
+	if (mclk != s5k2xx->data->mclk) {
 		dev_err(dev, "external clock %d is not supported", mclk);
 		return -EINVAL;
 	}

--- a/drivers/media/i2c/s5k2xx.c
+++ b/drivers/media/i2c/s5k2xx.c
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0
 // Copyright (c) 2019 Intel Corporation.
-
 #include <linux/clk.h>
 #include <linux/delay.h>
 #include <linux/gpio/consumer.h>
@@ -1463,7 +1462,7 @@ static struct i2c_driver s5k2xx_i2c_driver = {
 		.pm = &s5k2xx_pm_ops,
 		.of_match_table	= of_match_ptr(s5k2xx_of_match),
 	},
-	.probe_new = s5k2xx_probe,
+	.probe = s5k2xx_probe,
 	.remove = s5k2xx_remove,
 };
 

--- a/drivers/media/i2c/sr556.c
+++ b/drivers/media/i2c/sr556.c
@@ -1036,7 +1036,7 @@ static struct i2c_driver sr556_i2c_driver = {
 		.pm = &sr556_pm_ops,
 		.of_match_table	= of_match_ptr(sr556_of_match),
 	},
-	.probe_new = sr556_probe,
+	.probe = sr556_probe,
 	.remove = sr556_remove,
 };
 

--- a/drivers/media/platform/qcom/camss/camss-vfe-4-1.c
+++ b/drivers/media/platform/qcom/camss/camss-vfe-4-1.c
@@ -938,7 +938,14 @@ static irqreturn_t vfe_isr(int irq, void *dev)
  */
 static void vfe_pm_domain_off(struct vfe_device *vfe)
 {
-	/* nop */
+	struct camss *camss;
+
+	if (!vfe)
+		return;
+
+	camss = vfe->camss;
+
+	device_link_del(camss->genpd_link[vfe->id]);
 }
 
 /*
@@ -947,6 +954,17 @@ static void vfe_pm_domain_off(struct vfe_device *vfe)
  */
 static int vfe_pm_domain_on(struct vfe_device *vfe)
 {
+	struct camss *camss = vfe->camss;
+	enum vfe_line_id id = vfe->id;
+
+	camss->genpd_link[id] = device_link_add(camss->dev, camss->genpd[id], DL_FLAG_STATELESS |
+						DL_FLAG_PM_RUNTIME | DL_FLAG_RPM_ACTIVE);
+
+	if (!camss->genpd_link[id]) {
+		dev_err(camss->dev, "Failed to add VFE#%d to power domain\n", id);
+		return -EINVAL;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Changes:
- Fix power domain left on off
- Fix s5k3l8 clock rates
- Enable s5k3l8 for xiaomi-mido
- Enable ov5675 for xiaomi-vince

Megapixels config: 
[xiaomi,mido.txt](https://github.com/msm8953-mainline/linux/files/13403241/xiaomi.mido.txt)
[xiaomi,vince.txt](https://github.com/msm8953-mainline/linux/files/13403242/xiaomi.vince.txt)
> Change the extension to .ini
