### PR TITLE
Sound related fixes for xiaomi devices

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
@@ -177,3 +177,8 @@
 
 	status = "okay";
 };
+
+&wcd_codec {
+	qcom,mbhc-vthreshold-high = <91 259 488 488 488>;
+	qcom,mbhc-vthreshold-low = <91 259 488 488 488>;
+};

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-markw.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-markw.dts
@@ -14,7 +14,7 @@
 	speaker_amp: audio-amplifier {
 		compatible = "awinic,aw8738";
 		mode-gpios = <&tlmm 96 GPIO_ACTIVE_HIGH>;
-		awinic,mode = <3>;
+		awinic,mode = <5>;
 		sound-name-prefix = "Speaker Amp";
 	};
 
@@ -185,7 +185,11 @@
 	audio-routing =
 		"AMIC1", "MIC BIAS External1",
 		"AMIC2", "MIC BIAS Internal2",
-		"AMIC3", "MIC BIAS External1";
+		"AMIC3", "MIC BIAS External1",
+		"MM_DL1", "MultiMedia1 Playback",
+		"MM_DL3", "MultiMedia3 Playback",
+		"MM_DL4", "MultiMedia4 Playback",
+		"MultiMedia2 Capture", "MM_UL2";
 
 	pinctrl-0 = <&cdc_pdm_lines_act &cdc_pdm_lines_2_act &cdc_pdm_comp_lines_act>;
 	pinctrl-1 = <&cdc_pdm_lines_sus &cdc_pdm_lines_2_sus &cdc_pdm_comp_lines_sus>;
@@ -200,4 +204,6 @@
 
 &wcd_codec {
 	/delete-property/ qcom,gnd-jack-type-normally-open;
+	qcom,mbhc-vthreshold-high = <75 225 450 510 540>;
+	qcom,mbhc-vthreshold-low = <25 200 325 500 530>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
@@ -141,7 +141,11 @@
 	audio-routing =
 		"AMIC1", "MIC BIAS External1",
 		"AMIC2", "MIC BIAS Internal2",
-		"AMIC3", "MIC BIAS External1";
+		"AMIC3", "MIC BIAS External1",
+		"MM_DL1", "MultiMedia1 Playback",
+		"MM_DL3", "MultiMedia3 Playback",
+		"MM_DL4", "MultiMedia4 Playback",
+		"MultiMedia2 Capture", "MM_UL2";
 
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&cdc_pdm_lines_act &cdc_pdm_lines_2_act &cdc_pdm_comp_lines_act>;
@@ -157,4 +161,6 @@
 &wcd_codec {
 	/delete-property/ qcom,gnd-jack-type-normally-open;
 	/delete-property/ qcom,hphl-jack-type-normally-open;
+	qcom,mbhc-vthreshold-high = <73 233 438 438 438>;
+	qcom,mbhc-vthreshold-low = <73 233 438 438 438>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-tissot.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-tissot.dts
@@ -205,7 +205,11 @@
 	audio-routing =
 		"AMIC1", "MIC BIAS External1",
 		"AMIC2", "MIC BIAS Internal2",
-		"AMIC3", "MIC BIAS External1";
+		"AMIC3", "MIC BIAS External1",
+		"MM_DL1", "MultiMedia1 Playback",
+		"MM_DL3", "MultiMedia3 Playback",
+		"MM_DL4", "MultiMedia4 Playback",
+		"MultiMedia2 Capture", "MM_UL2";
 
 	quinary-mi2s-dai-link {
 		link-name = "Quinary MI2S";
@@ -269,4 +273,9 @@
 
 &wcnss_iris {
 	compatible = "qcom,wcn3680";
+};
+
+&wcd_codec {
+	qcom,mbhc-vthreshold-high = <91 259 488 488 488>;
+	qcom,mbhc-vthreshold-low = <91 259 488 488 488>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
@@ -188,3 +188,8 @@
 
 	status = "okay";
 };
+
+&wcd_codec {
+	qcom,mbhc-vthreshold-high = <91 259 488 488 488>;
+	qcom,mbhc-vthreshold-low = <91 259 488 488 488>;
+};

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-ysl.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-ysl.dts
@@ -22,9 +22,9 @@
 	};
 
 	speaker_amp: audio-amplifier {
-		compatible = "awinic,aw8738";
+		compatible = "awinic,aw87318", "awinic,aw8738";
 		mode-gpios = <&tlmm 139 GPIO_ACTIVE_HIGH>;
-		awinic,mode = <5>;
+		awinic,mode = <2>;
 		sound-name-prefix = "Speaker Amp";
 	};
 
@@ -117,8 +117,7 @@
 };
 
 &wcnss_iris {
-	/* Device has a WCN3615 */
-	compatible = "qcom,wcn3620";
+	compatible = "qcom,wnc3615", "qcom,wcn3620";
 };
 
 &panel {
@@ -142,10 +141,6 @@
 	model = "xiaomi-ysl";
 
 	aux-devs = <&speaker_amp>;
-	audio-routing =
-		"AMIC1", "MIC BIAS External1",
-		"AMIC2", "MIC BIAS External2",
-		"AMIC3", "MIC BIAS External1";
 
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&cdc_pdm_lines_act &cdc_pdm_lines_2_act &cdc_pdm_comp_lines_act>;
@@ -160,6 +155,8 @@
 
 &wcd_codec {
 	qcom,micbias2-ext-cap;
+	qcom,mbhc-vthreshold-high = <100 200 450 500 500>;
+	qcom,mbhc-vthreshold-low = <100 200 450 500 500>;
 };
 
 &tlmm {

--- a/arch/arm64/boot/dts/qcom/sdm632-xiaomi-onclite.dts
+++ b/arch/arm64/boot/dts/qcom/sdm632-xiaomi-onclite.dts
@@ -356,8 +356,8 @@
 &wcd_codec {
 	qcom,gnd-jack-type-normally-open;
 	qcom,hphl-jack-type-normally-open;
-	qcom,mbhc-vthreshold-high = <75 150 237 450 500>;
-	qcom,mbhc-vthreshold-low = <75 150 237 450 500>;
+	qcom,mbhc-vthreshold-high = <75 225 450 500 500>;
+	qcom,mbhc-vthreshold-low = <75 225 450 500 500>;
 	qcom,micbias1-ext-cap;
 	qcom,micbias2-ext-cap;
 
@@ -375,7 +375,7 @@
 };
 
 &wcnss_iris {
-	compatible = "qcom,wcn3620";
+	compatible = "qcom,wcn3615", "qcom,wcn3620";
 
 	vddxo-supply = <&pm8953_l7>;
 	vddrfa-supply = <&pm8953_l19>;


### PR DESCRIPTION
I have corrected some properties related to wcd_codec, and snd_card, wcnss_iris.
This PR contains fixes for mido, vince, tissot, daisy, markw, ysl and onclite.