### PR TITLE
Add initial rear camera support for mido and markw

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-markw.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-markw.dts
@@ -143,6 +143,30 @@
 	voltage-max-design-microvolt = <4380000>;
 };
 
+&camss {
+	status = "okay";
+	vdda-supply = <&pm8953_s3>;
+
+	ports {
+		port@0 {
+			reg = <0>;
+			csiphy0_ep: endpoint {
+				clock-lanes = <7>;
+				data-lanes = <0 1 2 3>;
+				remote-endpoint = <&rear_cam_ep>;
+			};
+		};
+		port@2 {
+			reg = <2>;
+			csiphy2_ep: endpoint {
+				clock-lanes = <7>;
+				data-lanes = <0 1>;
+				remote-endpoint = <&front_cam_ep>;
+			};
+		};
+	};
+};
+
 &cci {
 	pinctrl-names = "default";
 	pinctrl-0 = <&cci0_default>,
@@ -151,6 +175,34 @@
 		    <&camss_mclk1_default>;
 
 	status = "okay";
+};
+
+&cci_i2c0 {
+	camera-sensor@2d { // Primary rear camera
+		compatible = "samsung,s5k3l8";
+
+		reg = <0x2d>;
+
+		clocks = <&gcc GCC_CAMSS_MCLK0_CLK>;
+		clock-frequency = <19200000>;
+
+		reset-gpios = <&tlmm 40 GPIO_ACTIVE_LOW>;
+
+		avdd-supply= <&pm8953_l22>;
+		dvdd-supply = <&pm8953_l2>;
+		vio-supply = <&pm8953_l6>;
+		aux-supply = <&pm8953_l17>;
+		status = "okay";
+
+		orientation = <1>;
+
+		port {
+			rear_cam_ep: endpoint {
+				data-lanes = <0 1 2 3>;
+				remote-endpoint = <&csiphy0_ep>;
+			};
+		};
+	};
 };
 
 &cci_i2c1 {
@@ -180,22 +232,6 @@
 				data-lanes = <0 1>;
 				remote-endpoint = <&csiphy2_ep>;
 				link-frequencies = /bits/ 64 <450000000>;
-			};
-		};
-	};
-};
-
-&camss {
-	status = "okay";
-	vdda-supply = <&pm8953_s3>;
-
-	ports {
-		port@2 {
-			reg = <2>;
-			csiphy2_ep: endpoint {
-				clock-lanes = <7>;
-				data-lanes = <0 1>;
-				remote-endpoint = <&front_cam_ep>;
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
@@ -124,6 +124,61 @@
 	voltage-max-design-microvolt = <4380000>;
 };
 
+&camss {
+	status = "okay";
+	vdda-supply = <&pm8953_s3>;
+
+	ports {
+		port@0 {
+			reg = <0>;
+			csiphy0_ep: endpoint {
+				clock-lanes = <7>;
+				data-lanes = <0 1 2 3>;
+				remote-endpoint = <&rear_cam_ep>;
+			};
+		};
+	};
+};
+
+&cci {
+	pinctrl-names = "default";
+	pinctrl-0 = <&cci0_default>,
+		    <&cci1_default>,
+		    <&camss_mclk0_default>,
+		    <&camss_mclk1_default>;
+
+	status = "okay";
+};
+
+&cci_i2c0 {
+	camera-sensor@10 { // Primary rear camera
+		compatible = "samsung,s5k3l8";
+
+		reg = <0x10>;
+
+		clocks = <&gcc GCC_CAMSS_MCLK0_CLK>;
+		clock-frequency = <19200000>;
+
+		reset-gpios = <&tlmm 40 GPIO_ACTIVE_LOW>;
+
+		avdd-supply= <&pm8953_l22>;
+		dvdd-supply = <&pm8953_l2>;
+		vio-supply = <&pm8953_l6>;
+		aux-supply = <&pm8953_l17>;
+
+		orientation = <1>;
+
+		status = "okay";
+
+		port {
+			rear_cam_ep: endpoint {
+				data-lanes = <0 1 2 3>;
+				remote-endpoint = <&csiphy0_ep>;
+			};
+		};
+	};
+};
+
 &ft5406_ts {
 	status = "okay";
 

--- a/drivers/media/i2c/s5k2xx.c
+++ b/drivers/media/i2c/s5k2xx.c
@@ -16,6 +16,7 @@
 #include <media/v4l2-fwnode.h>
 
 #define S5K2XX_MCLK			24000000
+#define S5K3L8_MCLK			19200000
 #define S5K2XX_DATA_LANES		4
 #define S5K2XX_MAX_COLOR_DEPTH		10
 #define S5K2XX_MAX_COLOR_VAL		(BIT(S5K2XX_MAX_COLOR_DEPTH) - 1)
@@ -118,6 +119,7 @@ struct s5k2xx_data {
 	const struct s5k2xx_mode *modes;
 	size_t num_modes;
 	const struct reg_sequence *init_regs;
+	const u32 mclk;
 	u32 num_init_regs;
 };
 
@@ -251,6 +253,7 @@ static struct s5k2xx_data s5k2p6sx_data = {
 	.num_modes = ARRAY_SIZE(s5k2p6_modes),
 	.init_regs = s5k2p6_init,
 	.num_init_regs = ARRAY_SIZE(s5k2p6_init),
+	.mclk = S5K2XX_MCLK,
 };
 
 static const struct reg_sequence s5k2x7_init[] = {
@@ -561,6 +564,7 @@ static struct s5k2xx_data s5k2x7sp_data = {
 	.num_modes = ARRAY_SIZE(s5k2x7_modes),
 	.init_regs = s5k2x7_init,
 	.num_init_regs = ARRAY_SIZE(s5k2x7_init),
+	.mclk = S5K2XX_MCLK,
 };
 
 static const struct reg_sequence s5k3l8_init[] = {
@@ -703,6 +707,7 @@ static struct s5k2xx_data s5k3l8_data = {
 	.num_modes = ARRAY_SIZE(s5k3l8_modes),
 	.init_regs = s5k3l8_init,
 	.num_init_regs = ARRAY_SIZE(s5k3l8_init),
+	.mclk = S5K3L8_MCLK,
 };
 
 struct s5k2xx {
@@ -1057,7 +1062,7 @@ static int s5k2xx_power_on(struct device *dev)
 	}
 
 	if (s5k2xx->mclk) {
-		ret = clk_set_rate(s5k2xx->mclk, S5K2XX_MCLK);
+		ret = clk_set_rate(s5k2xx->mclk, s5k2xx->data->mclk);
 		if (ret) {
 			dev_err(dev, "can't set clock frequency");
 			return ret;
@@ -1283,7 +1288,7 @@ static int s5k2xx_check_hwcfg(struct s5k2xx *s5k2xx, struct device *dev)
 		return ret;
 	}
 
-	if (mclk != S5K2XX_MCLK) {
+	if (mclk != s5k2xx->data->mclk) {
 		dev_err(dev, "external clock %d is not supported", mclk);
 		return -EINVAL;
 	}


### PR DESCRIPTION
Changes:
- Add ability s5k3l8 use different clock rates (This is a workaround it should be removed when we find a better solution)
- Enable s5k3l8 for xiaomi-mido
- Enable ov5675 for xiaomi-vince

Megapixels config: 
[xiaomi,mido.txt](https://github.com/msm8953-mainline/linux/files/13403241/xiaomi.mido.txt)
[xiaomi,vince.txt](https://github.com/msm8953-mainline/linux/files/13403242/xiaomi.vince.txt)
> Change the extension to .ini