### PR TITLE
Enable goodix gt917d on mido

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
@@ -125,6 +125,13 @@
 	touchscreen-size-y = <1920>;
 };
 
+&gt917d_ts {
+	status = "disabled";
+
+	touchscreen-size-x = <1080>;
+	touchscreen-size-y = <1920>;
+};
+
 &panel {
 	compatible = "xiaomi,mido-panel";
 };


### PR DESCRIPTION
Add gt917d node for xiaomi-mido. It is disabled by default.