### PR TITLE
Enable MPM interrupt  controller

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8953.dtsi
@@ -633,6 +633,24 @@
 		reg = <0 0 0 0>;
 	};
 
+	mpm: interrupt-controller@601d4 {
+		compatible = "qcom,mpm";
+		qcom,rpm-msg-ram = <&apss_mpm>;
+		interrupts = <GIC_SPI 171 IRQ_TYPE_EDGE_RISING>;
+		mboxes = <&apcs 1>;
+		interrupt-controller;
+		#interrupt-cells = <2>;
+		#power-domain-cells = <0>;
+		interrupt-parent = <&intc>;
+		qcom,mpm-pin-count = <96>;
+		qcom,mpm-pin-map = <2 184>,  /* tsens_upper_lower_int */
+				   <37 220>, /* qmp_usb3_lfps_rxterm_irq -> ss_phy_irq */
+				   <49 136>, /* qusb2phy_dpse_hv -> hs_phy_irq*/
+				   <53 72>, /* mdss_irq */
+				   <58 136>, /* qusb2phy_dmse_hv -> hs_phy_irq*/
+				   <88 190>; /* ee0_krait_hlos_spmi_periph_irq */
+	};
+
 	pmu {
 		compatible = "arm,cortex-a53-pmu";
 		interrupts = <GIC_PPI 7 (GIC_CPU_MASK_SIMPLE(8) | IRQ_TYPE_LEVEL_HIGH)>;
@@ -694,11 +712,13 @@
 		CLUSTER0_PD: power-domain-cluster0 {
 			#power-domain-cells = <0>;
 			domain-idle-states = <&CLUSTER_RET>, <&CLUSTER_GDHS>, <&CLUSTER_PC>;
+			power-domains = <&mpm>;
 		};
 
 		CLUSTER1_PD: power-domain-cluster1 {
 			#power-domain-cells = <0>;
 			domain-idle-states = <&CLUSTER_RET>, <&CLUSTER_GDHS>, <&CLUSTER_PC>;
+			power-domains = <&mpm>;
 		};
 	};
 
@@ -958,6 +978,13 @@
 		rpm_msg_ram: sram@60000 {
 			compatible = "qcom,rpm-msg-ram";
 			reg = <0x00060000 0x8000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges = <0 0x00060000 0x8000>;
+
+			apss_mpm: sram@1d4 {
+				reg = <0x1d4 0x48>;
+			};
 		};
 
 		hsusb_phy: phy@79000 {
@@ -1012,8 +1039,8 @@
 			reg = <0x004a9000 0x1000>, /* TM */
 			      <0x004a8000 0x1000>; /* SROT */
 			#qcom,sensors = <16>;
-			interrupts = <GIC_SPI 184 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 314 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts-extended = <&mpm 2 IRQ_TYPE_LEVEL_HIGH>,
+					      <&intc GIC_SPI 314 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "uplow", "critical";
 			#thermal-sensor-cells = <1>;
 		};
@@ -1052,6 +1079,7 @@
 			interrupts = <GIC_SPI 208 IRQ_TYPE_LEVEL_HIGH>;
 			gpio-controller;
 			gpio-ranges = <&tlmm 0 0 142>;
+			wakeup-parent = <&mpm>;
 			#gpio-cells = <2>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
@@ -2176,7 +2204,7 @@
 			      <0x0200a000 0x2100>;
 			reg-names = "core", "chnls", "obsrvr", "intr", "cnfg";
 			interrupt-names = "periph_irq";
-			interrupts = <GIC_SPI 190 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts-extended = <&mpm 88 IRQ_TYPE_LEVEL_HIGH>;
 			qcom,ee = <0>;
 			qcom,channel = <0>;
 			interrupt-controller;
@@ -2247,8 +2275,8 @@
 			#size-cells = <1>;
 			ranges;
 
-			interrupts = <GIC_SPI 136 IRQ_TYPE_LEVEL_HIGH>,
-				     <GIC_SPI 220 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts-extended = <&mpm 49 IRQ_TYPE_LEVEL_HIGH>,
+					      <&mpm 37 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "hs_phy_irq", "ss_phy_irq";
 
 			clocks = <&gcc GCC_USB_PHY_CFG_AHB_CLK>,

--- a/drivers/irqchip/irq-qcom-mpm.c
+++ b/drivers/irqchip/irq-qcom-mpm.c
@@ -14,6 +14,7 @@
 #include <linux/mailbox_client.h>
 #include <linux/module.h>
 #include <linux/of.h>
+#include <linux/of_address.h>
 #include <linux/of_platform.h>
 #include <linux/platform_device.h>
 #include <linux/pm_domain.h>
@@ -322,8 +323,10 @@ static int qcom_mpm_init(struct device_node *np, struct device_node *parent)
 	struct device *dev = &pdev->dev;
 	struct irq_domain *parent_domain;
 	struct generic_pm_domain *genpd;
+	struct device_node *msgram_np;
 	struct qcom_mpm_priv *priv;
 	unsigned int pin_cnt;
+	struct resource res;
 	int i, irq;
 	int ret;
 
@@ -374,9 +377,26 @@ static int qcom_mpm_init(struct device_node *np, struct device_node *parent)
 
 	raw_spin_lock_init(&priv->lock);
 
-	priv->base = devm_platform_ioremap_resource(pdev, 0);
-	if (IS_ERR(priv->base))
-		return PTR_ERR(priv->base);
+	/* If we have a handle to an RPM message ram partition, use it. */
+	msgram_np = of_parse_phandle(np, "qcom,rpm-msg-ram", 0);
+	if (msgram_np) {
+		ret = of_address_to_resource(msgram_np, 0, &res);
+		if (ret) {
+			of_node_put(msgram_np);
+			return ret;
+		}
+
+		/* Don't use devm_ioremap_resource, as we're accessing a shared region. */
+		priv->base = devm_ioremap(dev, res.start, resource_size(&res));
+		of_node_put(msgram_np);
+		if (IS_ERR(priv->base))
+			return PTR_ERR(priv->base);
+	} else {
+		/* Otherwise, fall back to simple MMIO. */
+		priv->base = devm_platform_ioremap_resource(pdev, 0);
+		if (IS_ERR(priv->base))
+			return PTR_ERR(priv->base);
+	}
 
 	for (i = 0; i < priv->reg_stride; i++) {
 		qcom_mpm_write(priv, MPM_REG_ENABLE, i, 0);

--- a/drivers/pinctrl/qcom/pinctrl-msm8953.c
+++ b/drivers/pinctrl/qcom/pinctrl-msm8953.c
@@ -1790,6 +1790,20 @@ static const struct msm_pingroup msm8953_groups[] = {
 	SDC_QDSD_PINGROUP(sdc2_data, 0x109000, 9, 0),
 };
 
+static const struct msm_gpio_wakeirq_map msm8953_mpm_map[] = {
+	{38, 3}, {1, 4}, {5, 5}, {9, 6}, {37, 8},
+	{36, 9}, {13, 10}, {35, 11}, {17, 12}, {21, 13},
+	{54, 14}, {34, 15}, {31, 16}, {58, 17}, {28, 18},
+	{42, 19}, {25, 20}, {12, 21}, {43, 22}, {44, 23},
+	{45, 24}, {46, 25}, {48, 26}, {65, 27}, {93, 28},
+	{97, 29}, {63, 30}, {70, 31}, {71, 32}, {72, 33},
+	{81, 34}, {85, 35}, {90, 36}, {67, 50}, {73, 51},
+	{74, 52}, {62, 53}, {59, 59}, {60, 60}, {61, 61},
+	{86, 62}, {87, 63}, {91, 64}, {129, 65}, {130, 66},
+	{131, 67}, {132, 68}, {133, 69}, {137, 70}, {138, 71},
+	{139, 72}, {140, 73}, {141, 74},
+};
+
 static const struct msm_pinctrl_soc_data msm8953_pinctrl = {
 	.pins = msm8953_pins,
 	.npins = ARRAY_SIZE(msm8953_pins),
@@ -1798,6 +1812,9 @@ static const struct msm_pinctrl_soc_data msm8953_pinctrl = {
 	.groups = msm8953_groups,
 	.ngroups = ARRAY_SIZE(msm8953_groups),
 	.ngpios = 142,
+	.wakeirq_map = msm8953_mpm_map,
+	.nwakeirq_map = ARRAY_SIZE(msm8953_mpm_map),
+	.wakeirq_dual_edge_errata = true,
 };
 
 static int msm8953_pinctrl_probe(struct platform_device *pdev)


### PR DESCRIPTION
This enable the MPM interrupt controller which is supposed to be able to wake up the system from suspend. Next I'll put the IPA v2 patches on top of this to see if it's possible to receive SMS when suspended.