### PR TITLE
potter: add *-supply properties to simplefb dts

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-motorola-potter.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-motorola-potter.dts
@@ -34,6 +34,9 @@
 
 			power-domains = <&gcc MDSS_GDSC>;
 
+			vsp-supply = <&lab_vreg>;
+			vsn-supply = <&ibb_vreg>;
+
 			clocks = <&gcc GCC_MDSS_AHB_CLK>,
 				 <&gcc GCC_MDSS_AXI_CLK>,
 				 <&gcc GCC_MDSS_VSYNC_CLK>,


### PR DESCRIPTION
When I boot 6.6.10 on a motorola-potter, the screen turns off after 15-30 seconds.  There's a line "ibb: disabling" in the log which appears at about the same time. This patch adds `{vsp,vsn}-supply` properties pointing at lab and ibb regulators, which seems necessary to stop this from happening.

(It's probable this bug doesn't manifest when the GPU stuff is all working properly, but mine isn't)

I'm not an expert, so if this all looks wrong and misguided, that might be because it's wrong and misguided - feedback welcome