### PR TITLE
Enable irled on xiaomi-mido

### DIFF
--- a/Documentation/devicetree/bindings/leds/leds-qcom-lpg.yaml
+++ b/Documentation/devicetree/bindings/leds/leds-qcom-lpg.yaml
@@ -27,6 +27,7 @@ properties:
           - qcom,pm8994-lpg
           - qcom,pmc8180c-lpg
           - qcom,pmi632-lpg
+          - qcom,pmi8950-pwm
           - qcom,pmi8994-lpg
           - qcom,pmi8998-lpg
           - qcom,pmk8550-pwm

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
@@ -2,6 +2,7 @@
 /dts-v1/;
 
 #include "msm8953-xiaomi-common.dtsi"
+#include "dt-bindings/pinctrl/qcom,pmic-gpio.h"
 
 /delete-node/ &cont_splash_mem;
 /delete-node/ &qseecom_mem;
@@ -74,6 +75,11 @@
 		};
 	};
 
+	irled {
+		compatible = "pwm-ir-tx";
+		pwms = <&pmi8950_pwm 0 0>;
+	};
+
 	reserved-memory {
 		qseecom_mem: qseecom@84a00000 {
 			reg = <0x0 0x84a00000 0x0 0x1900000>;
@@ -134,6 +140,25 @@
 
 &panel {
 	compatible = "xiaomi,mido-panel";
+};
+
+&pmi8950_gpios {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_ir_default>;
+
+	pwm_ir_default: pwm_ir_default {
+		pwm_ir_state {
+			pins = "gpio1";
+			output-low;
+			bias-pull-down;
+			function = "func1";
+			qcom,drive-strength = <PMIC_GPIO_STRENGTH_MED>;
+		};
+	};
+};
+
+&pmi8950_pwm {
+	status = "okay";
 };
 
 &sdhc_2 {

--- a/arch/arm64/boot/dts/qcom/pmi8950.dtsi
+++ b/arch/arm64/boot/dts/qcom/pmi8950.dtsi
@@ -174,6 +174,15 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
+		pmi8950_pwm: pwm@b000 {
+			compatible = "qcom,pmi8950-pwm";
+			reg = <0xb000 0x100>;
+
+			#pwm-cells = <2>;
+
+			status = "disabled";
+		};
+
 		labibb {
 			compatible = "qcom,pmi8998-lab-ibb";
 			lab_vreg: lab {

--- a/drivers/leds/rgb/leds-qcom-lpg.c
+++ b/drivers/leds/rgb/leds-qcom-lpg.c
@@ -1618,6 +1618,13 @@ static const struct lpg_data pm8941_lpg_data = {
 	},
 };
 
+static const struct lpg_data pmi8950_pwm_data = {
+	.num_channels = 1,
+	.channels = (const struct lpg_channel_data[]) {
+		{ .base = 0xb000 },
+	},
+};
+
 static const struct lpg_data pm8994_lpg_data = {
 	.lut_base = 0xb000,
 	.lut_size = 64,
@@ -1741,6 +1748,7 @@ static const struct of_device_id lpg_of_table[] = {
 	{ .compatible = "qcom,pm8941-lpg", .data = &pm8941_lpg_data },
 	{ .compatible = "qcom,pm8994-lpg", .data = &pm8994_lpg_data },
 	{ .compatible = "qcom,pmi632-lpg", .data = &pmi632_lpg_data },
+        { .compatible = "qcom,pmi8950-pwm", .data = &pmi8950_pwm_data },
 	{ .compatible = "qcom,pmi8994-lpg", .data = &pmi8994_lpg_data },
 	{ .compatible = "qcom,pmi8998-lpg", .data = &pmi8998_lpg_data },
 	{ .compatible = "qcom,pmc8180c-lpg", .data = &pm8150l_lpg_data },


### PR DESCRIPTION
This PR add support for irled on xiaomi mido it is based on #96.

For test rc decoders and pwm-ir-tx should be enabled in the config.

It works fine with ir-ctl from v4l-utils
```
# ir-ctl -S rc5:0x1e01
```