### PR TITLE
 touchscreens selected by lk2nd detection need to be declared and disabled

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
@@ -151,7 +151,7 @@
 };
 
 &rmi4_ts {
-	status = "okay";
+	status = "disabled";
 };
 
 &sound_card {


### PR DESCRIPTION
All the touchscreens selected by lk2nd detection bindings (panel <-> touchscreen)  need to be stay "disabled"
related to
https://github.com/msm8953-mainline/lk2nd/pull/61