### PR TITLE
xiaomi-{markw,mido,vince}: Switch to lk2nd touchscreen selection

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-markw.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-markw.dts
@@ -240,7 +240,7 @@
 };
 
 &ft5406_ts {
-	status = "okay";
+	status = "disabled";
 
 	compatible = "edt,edt-ft5336", "edt,edt-ft5306";
 	touchscreen-size-x = <1080>;
@@ -248,7 +248,7 @@
 };
 
 &i2c_3 {
-	status = "okay";
+	status = "disabled";
 
 	touchscreen@4a {
 		compatible = "atmel,maxtouch";

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-mido.dts
@@ -181,7 +181,7 @@
 };
 
 &ft5406_ts {
-	status = "okay";
+	status = "disabled";
 
 	touchscreen-size-x = <1080>;
 	touchscreen-size-y = <1920>;

--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-vince.dts
@@ -212,7 +212,7 @@
 };
 
 &rmi4_ts {
-	status = "okay";
+	status = "disabled";
 };
 
 &sound_card {


### PR DESCRIPTION
For lk2nd touchscreen selection all touchscreen should be disabled by default.

Related lk2nd PR: https://github.com/msm8953-mainline/lk2nd/pull/62