### PR TITLE
Declare missing vio-supply for aw2013 led and suppress dmesg message

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-common.dtsi
@@ -99,6 +99,7 @@
 		reg = <0x45>;
 
 		vcc-supply = <&pm8953_l10>;
+		vio-supply = <&pm8953_l5>;
 
 		status = "disabled";
 


### PR DESCRIPTION
This declares `vio-supply` for aw2013 led as stated also downstream
https://github.com/GhostMaster69-dev/android_kernel_xiaomi_vince/blob/055d92b42a08a7f2a0e93f8bfea625961748fc1c/arch/arm64/boot/dts/qcom/vince/vince-qrd.dtsi#L441

Suppress dmesg warning 
`leds-aw2013: supply vio not found, using dummy regulator`