### PR TITLE
arm64: dts: qcom: sdm450-samsung-a6plte-r4: Use samsung-gmax for &sound_card

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm450-samsung-a6plte-r4.dts
+++ b/arch/arm64/boot/dts/qcom/sdm450-samsung-a6plte-r4.dts
@@ -720,7 +720,7 @@
 };
 
 &sound_card {
-	model = "samsung-a2015";
+	model = "samsung-gmax";
 	audio-routing =
 		"AMIC1", "MIC BIAS External1",
 		"AMIC2", "MIC BIAS Internal2",


### PR DESCRIPTION
Similar to Grand Max, A6+ has only one microphone.