### PR TITLE
panel-xiaomi-ysl-ili7807d: fix glitches

### DIFF
--- a/drivers/gpu/drm/panel/msm8953-generated/panel-xiaomi-ysl-ili7807d.c
+++ b/drivers/gpu/drm/panel/msm8953-generated/panel-xiaomi-ysl-ili7807d.c
@@ -140,6 +140,7 @@ static int auo720_enable(struct drm_panel *panel)
 	struct device *dev = &ctx->dsi->dev;
 	int ret;
 
+	auo720_off(ctx);
 	ret = auo720_on(ctx);
 	if (ret < 0) {
 		dev_err(dev, "Failed to initialize panel: %d\n", ret);


### PR DESCRIPTION
With mdp5 ili7807d had some glitches until the first panel off/on, with dpu this issue dissapeard. This commit is a fix for mdp5.