### PR TITLE
arm64: dts: qcom: msm8953: xiaomi-daisy: fix backlight stripes

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
+++ b/arch/arm64/boot/dts/qcom/msm8953-xiaomi-daisy.dts
@@ -183,6 +183,10 @@
 	regulator-min-microvolt = <1200000>;
 };
 
+&pmi8950_wled {
+	qcom,num-strings = <3>;
+};
+
 &battery {
 	charge-full-design-microamp-hours = <4000000>;
 	constant-charge-current-max-microamp = <1000000>;


### PR DESCRIPTION
Xiaomi Mi A2 Lite needs qcom,num-strings to be set 3 instead of 2 in pmi8950_wled, this fixes stripes in backlight.