### PR TITLE
fixup! wifi: ath10k: add support for QCA9379 hw1.0 SDIO

### DIFF
--- a/drivers/net/wireless/ath/ath10k/core.c
+++ b/drivers/net/wireless/ath/ath10k/core.c
@@ -678,7 +678,6 @@ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
 		.hw_restart_disconnect = false,
 		.use_fw_tx_credits = true,
 		.delay_unmap_buffer = false,
-		.mcast_frame_registration = false,
 	},
 	{
 		.id = QCA4019_HW_1_0_DEV_VERSION,


### PR DESCRIPTION
This field is introduced in 6.8-rc1 so having it in 6.7.9 makes ath10k fail to build.