### PR TITLE
Use kernel BAM for ipa2_lite

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8953.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8953.dtsi
@@ -2548,11 +2548,12 @@
 
 		ipa: ipa@7900000 {
 			compatible = "qcom,ipa-lite-v2.6";
-			reg = <0x7900000 0x47000>;
+			reg = <0x07940000 0x5000>,
+			      <0x07945000 0x2000>;
+			reg-names = "ipa-reg", "ipa-shared";
 			clocks = <&rpmcc RPM_SMD_IPA_CLK>;
-			interrupts = <GIC_SPI 228 IRQ_TYPE_EDGE_RISING>,
-				     <GIC_SPI 230 IRQ_TYPE_LEVEL_HIGH>;
-			interrupt-names = "ipa", "dma";
+			interrupts = <GIC_SPI 228 IRQ_TYPE_EDGE_RISING>;
+			interrupt-names = "ipa";
 			interconnects = <&snoc MAS_IPA RPM_ACTIVE_TAG
 					 &bimc SLV_EBI RPM_ACTIVE_TAG>,
 					<&snoc MAS_IPA RPM_ACTIVE_TAG
@@ -2560,8 +2561,32 @@
 					<&bimc MAS_APPS_PROC RPM_ACTIVE_TAG
 					 &pcnoc SLV_IPA_CFG RPM_ACTIVE_TAG>;
 			interconnect-names = "ipa-mem", "ipa-imem", "cpu-cfg";
-			iommus = <&apps_iommu 0x18>;
+
+			dmas = <&ipa_bam 0>, <&ipa_bam 1>, <&ipa_bam 2>, <&ipa_bam 3>, <&ipa_bam 4>, <&ipa_bam 5>;
+			//       <&ipa_bam 6>, <&ipa_bam 7>, <&ipa_bam 8>, <&ipa_bam 9>;
+			dma-names = "test_tx", "test_rx", "ap_lan_rx", "cmd_tx", "ap_modem_tx", "ap_modem_rx";
+			//	    "modem_lan_tx", "modem_cmd_tx", "modem_lan_rx", "modem_ap_rx";
+			// FIXME: How can we make IPA work with BAM and IOMMU?
+			// currently it works either without the iommu entries in the bam and ipa_bam nodes
+			// or with iommu.passthrough=1 on the kernel cmdline (this seems to break venus probe)
+			//iommus = <&apps_iommu 0x18>;
 			modem-remoteproc = <&mpss>;
+		};
+
+		ipa_bam: dma@7904000 {
+			compatible = "qcom,bam-v1.7.0";
+			reg = <0x07904000 0x26934>;
+			interrupts = <GIC_SPI 230 IRQ_TYPE_LEVEL_HIGH>;
+			/* FIXME: use mem_clk */
+			clocks = <&rpmcc RPM_SMD_IPA_CLK>;
+			clock-names = "bam_clk";
+			#dma-cells = <1>;
+			qcom,ee = <0>;
+			// FIXME: How can we make IPA work with BAM and IOMMU?
+			// currently it works either without the iommu entries in the bam and ipa_bam nodes
+			// or with iommu.passthrough=1 on the kernel cmdline (this seems to break venus probe)
+			//iommus = <&apps_iommu 0x18>;
+			status = "okay";
 		};
 
 		i2c_4: i2c@78b8000 {

--- a/drivers/dma/qcom/bam_dma.c
+++ b/drivers/dma/qcom/bam_dma.c
@@ -71,6 +71,11 @@ struct bam_async_desc {
 
 	struct bam_desc_hw *curr_desc;
 
+	/* first descriptor position in fifo */
+	size_t fifo_index;
+	void *metadata;
+	size_t meta_len;
+
 	/* list node for the desc in the bam_chan list of descriptors */
 	struct list_head desc_node;
 	enum dma_transfer_direction dir;
@@ -636,6 +641,65 @@ static int bam_slave_config(struct dma_chan *chan,
 }
 
 /**
+ * bam_update_metadata - update metadata buffer
+ * @async_desc: BAM async descriptior
+ * @fifo: BAM FIFO to read metadata from
+ *
+ * Updates metadata buffer (transfer size) based on values
+ * read from FIFO descriptors
+ */
+
+static void bam_update_metadata(struct bam_async_desc *async_desc,
+				struct bam_desc_hw *fifo)
+{
+	unsigned int len = 0, i;
+
+	if (!async_desc->metadata)
+		return;
+
+	for (i = 0; i < async_desc->xfer_len; ++i) {
+		unsigned int pos = (i + async_desc->fifo_index) % MAX_DESCRIPTORS;
+
+		len += fifo[pos].size;
+	}
+
+	switch (async_desc->meta_len)  {
+	case 4:
+		*((u32 *)async_desc->metadata) = len;
+		break;
+	case 8:
+		*((u64 *)async_desc->metadata) = len;
+		break;
+	}
+}
+
+/**
+ * bam_attach_metadata - attach metadata buffer to the async descriptor
+ * @desc: async descriptor
+ * @data: buffer pointer
+ * @len: length of passed buffer
+ */
+static int bam_attach_metadata(struct dma_async_tx_descriptor *desc, void *data,
+			       size_t len)
+{
+	struct bam_async_desc *async_desc;
+
+	if (!data || !(len == 2 || len == 4 || len == 8))
+		return -EINVAL;
+
+	async_desc = container_of(desc, struct bam_async_desc, vd.tx);
+
+	async_desc->metadata = data;
+	async_desc->meta_len = len;
+
+	return 0;
+}
+
+static struct dma_descriptor_metadata_ops metadata_ops = {
+	.attach = bam_attach_metadata,
+};
+
+/**
  * bam_prep_slave_sg - Prep slave sg transaction
  *
  * @chan: dma channel
@@ -713,6 +777,8 @@ static struct dma_async_tx_descriptor *bam_prep_slave_sg(struct dma_chan *chan,
 			desc++;
 		} while (remainder > 0);
 	}
+
+	async_desc->vd.tx.metadata_ops = &metadata_ops;
 
 	return vchan_tx_prep(&bchan->vc, &async_desc->vd, flags);
 }
@@ -881,6 +947,11 @@ static u32 process_channel_irqs(struct bam_device *bdev)
 			 * it gets restarted by the tasklet
 			 */
 			if (!async_desc->num_desc) {
+				struct bam_desc_hw *fifo = PTR_ALIGN(bchan->fifo_virt,
+						sizeof(struct bam_desc_hw));
+
+				bam_update_metadata(async_desc, fifo);
+
 				vchan_cookie_complete(&async_desc->vd);
 			} else {
 				list_add(&async_desc->vd.node,
@@ -1094,6 +1165,8 @@ static void bam_start_dma(struct bam_chan *bchan)
 			       async_desc->xfer_len *
 			       sizeof(struct bam_desc_hw));
 		}
+
+		async_desc->fifo_index = bchan->tail;
 
 		bchan->tail += async_desc->xfer_len;
 		bchan->tail %= MAX_DESCRIPTORS;
@@ -1345,6 +1418,7 @@ static int bam_dma_probe(struct platform_device *pdev)
 	bdev->common.residue_granularity = DMA_RESIDUE_GRANULARITY_SEGMENT;
 	bdev->common.src_addr_widths = DMA_SLAVE_BUSWIDTH_4_BYTES;
 	bdev->common.dst_addr_widths = DMA_SLAVE_BUSWIDTH_4_BYTES;
+	bdev->common.desc_metadata_modes = DESC_METADATA_CLIENT;
 	bdev->common.device_alloc_chan_resources = bam_alloc_chan;
 	bdev->common.device_free_chan_resources = bam_free_chan;
 	bdev->common.device_prep_slave_sg = bam_prep_slave_sg;

--- a/drivers/dma/qcom/bam_dma.c
+++ b/drivers/dma/qcom/bam_dma.c
@@ -58,6 +58,7 @@ struct bam_desc_hw {
 #define DESC_FLAG_EOB BIT(13)
 #define DESC_FLAG_NWD BIT(12)
 #define DESC_FLAG_CMD BIT(11)
+#define DESC_FLAG_IMM BIT(8)
 
 struct bam_async_desc {
 	struct virt_dma_desc vd;
@@ -693,6 +694,8 @@ static struct dma_async_tx_descriptor *bam_prep_slave_sg(struct dma_chan *chan,
 		do {
 			if (flags & DMA_PREP_CMD)
 				desc->flags |= cpu_to_le16(DESC_FLAG_CMD);
+			else if (flags & DMA_PREP_IMM_CMD)
+				desc->flags |= cpu_to_le16(DESC_FLAG_IMM);
 
 			desc->addr = cpu_to_le32(sg_dma_address(sg) +
 						 curr_offset);

--- a/drivers/net/ipa2-lite/ipa-hw.h
+++ b/drivers/net/ipa2-lite/ipa-hw.h
@@ -3,8 +3,10 @@
  */
 
 #define IPA_BAM_BASE			0x4000
-#define IPA_BASE			0x40000
-#define IPA_SRAM_BASE			0x45000
+//#define IPA_BASE			0x40000
+#define IPA_BASE			0
+//#define IPA_SRAM_BASE			0x45000
+#define IPA_SRAM_BASE			0
 
 #define BAM_REG(off)			((off) + IPA_BAM_BASE)
 #define BAM_P_REG(off, pipe)		(BAM_REG(off) + (pipe) * 0x1000)
@@ -66,10 +68,10 @@
 #define REG_BAM_P_EVNT_GEN_TRSHLD(pipe)	BAM_P_REG(0x13828, (pipe))
 #define REG_BAM_P_FIFO_SIZES(pipe)	BAM_P_REG(0x13820, (pipe))
 
-struct __packed fifo_desc {
+struct __packed fifo_desc {  // this is similar to struct bam_desc_hw
 	__le32 addr;
-	union {
-		__le16 size;
+	union {              // in bam_desc_hw this is only __le16 size
+		__le16 size; // can the bam_dma.c code still be used here? Yes. Just use opcode as length.
 		__le16 opcode;
 	};
 	__le16 flags;

--- a/include/linux/dmaengine.h
+++ b/include/linux/dmaengine.h
@@ -202,6 +202,7 @@ enum dma_ctrl_flags {
 	DMA_PREP_CMD = (1 << 7),
 	DMA_PREP_REPEAT = (1 << 8),
 	DMA_PREP_LOAD_EOT = (1 << 9),
+	DMA_PREP_IMM_CMD = (1 << 10),
 };
 
 /**


### PR DESCRIPTION
This uses the BAM dmaengine driver for the ipa2_lite driver. It gives working mobile data in simple cases (accessing wikipedia works), but crashes when accessing youtube.

The crash when using youtube is caused by a NULL pointer in ipa_poll_tx, using netconsole I could observe
BUG_ON(!skb) being triggered.
```

	while (done < budget) {
		struct ipa_trans *trans;
		done++;
		trans = bam_channel_poll_one_new(ep);
		if (!trans)
			break;

		skb = trans->skb;
		BUG_ON(!skb);

		bytes += skb->len;
		packets++;

		dma_unmap_single(dev, trans->addr, skb->len, DMA_TO_DEVICE);
		dev_consume_skb_any(skb);

		ipa_trans_free(trans);
	}
```

Another issue is that I had to remove the iommus from the ipa and ipa_bam nodes to make BAM dma work.