### PR TITLE
rosy: add i2c sensors

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm450-xiaomi-rosy.dts
+++ b/arch/arm64/boot/dts/qcom/sdm450-xiaomi-rosy.dts
@@ -31,6 +31,40 @@
 			no-map;
 		};
 	};
+
+	i2c-sensors {
+		compatible = "i2c-gpio";
+		sda-gpios = <&tlmm 14 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&tlmm 15 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>; /* ~100 kHz */
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		magnetometer@c {
+			compatible = "asahi-kasei,ak09918";
+			reg = <0x0c>;
+
+			vdd-supply = <&pm8953_l10>;
+			vid-supply = <&pm8953_l6>;
+		};
+
+		light@48 {
+			compatible = "sensortek,stk3311";
+			reg = <0x48>;
+		};
+
+		imu@68 {
+			compatible = "bosch,bmi120";
+			reg = <0x68>;
+
+			vdd-supply = <&pm8953_l10>;
+			vddio-supply = <&pm8953_l6>;
+
+			mount-matrix = "1", "0", "0",
+					"0", "-1", "0",
+					"0", "0", "1";
+		};
+	};
 };
 
 &aw2013_led {


### PR DESCRIPTION
Add i2c sensors for gyroscope (bmi120), accelerometer (ak09918) and ALS (ltr579, no driver support yet).