### PR TITLE
Moto G6 USB-C OTG and VBUS support

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm450-motorola-ali.dts
+++ b/arch/arm64/boot/dts/qcom/sdm450-motorola-ali.dts
@@ -37,14 +37,6 @@
 		};
 	};
 
-	usb_otg_vreg: usb-otg-switch {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_otg_vreg";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		vin-supply = <&otg_vbus>;
-	};
-
 	reserved-memory {
 		qseecom_mem: qseecom@84300000 {
 			reg = <0x0 0x84300000 0x0 0x2000000>;
@@ -102,7 +94,7 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&fusb302_int_default>;
 
-		vbus-supply = <&usb_otg_vreg>;
+		vbus-supply = <&otg_vbus>;
 		usb-role-switch = <&usb3>;
 
 		connector {
@@ -405,6 +397,7 @@
 
 &usb3 {
 	dr_mode = "otg";
+	usb-psy-name = "qcom-smbchg-usb";
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm450-motorola-ali.dts
+++ b/arch/arm64/boot/dts/qcom/sdm450-motorola-ali.dts
@@ -7,6 +7,7 @@
 #include "sdm450.dtsi"
 #include "pm8953.dtsi"
 #include "pmi8950.dtsi"
+#include <dt-bindings/usb/pd.h>
 
 /delete-node/ &qseecom_mem;
 
@@ -34,6 +35,14 @@
 			gpios = <&tlmm 85 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_VOLUMEUP>;
 		};
+	};
+
+	usb_otg_vreg: usb-otg-switch {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_otg_vreg";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		vin-supply = <&otg_vbus>;
 	};
 
 	reserved-memory {
@@ -77,6 +86,48 @@
 		reset-gpios = <&tlmm 64 GPIO_ACTIVE_LOW>;
 		touchscreen-size-x = <1080>;
 		touchscreen-size-y = <2160>;
+	};
+};
+
+&i2c_1 {
+	status = "okay";
+
+	typec@22 {
+		compatible = "fcs,fusb302";
+		reg = <0x22>;
+
+		interrupt-parent = <&tlmm>;
+		interrupts = <9 IRQ_TYPE_LEVEL_LOW>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&fusb302_int_default>;
+
+		vbus-supply = <&usb_otg_vreg>;
+		usb-role-switch = <&usb3>;
+
+		connector {
+			compatible = "usb-c-connector";
+			label = "USB-C";
+			power-role = "dual";
+			data-role = "dual";
+			try-power-role = "sink";
+			typec-power-opmode = "default";
+			source-pdos = <PDO_FIXED(5000, 400,
+						 PDO_FIXED_DUAL_ROLE |
+						 PDO_FIXED_DATA_SWAP |
+						 PDO_FIXED_USB_COMM)>;
+			sink-pdos = <PDO_FIXED(5000, 400,
+					       PDO_FIXED_DUAL_ROLE |
+					       PDO_FIXED_DATA_SWAP |
+					       PDO_FIXED_USB_COMM)>;
+			op-sink-microwatt = <2500000>;
+
+			port {
+				fusb302_hs: endpoint {
+					remote-endpoint = <&usb_dwc3_hs>;
+				};
+			};
+		};
 	};
 };
 
@@ -159,6 +210,10 @@
 &pmi8950_smbcharger {
 	monitored-battery = <&battery>;
 	status = "okay";
+
+	otg_vbus: otg-vbus {
+		regulator-name = "otg-vbus";
+	};
 };
 
 &pmi8950_wled {
@@ -339,10 +394,22 @@
 		drive-strength = <0x08>;
 		bias-pull-up;
 	};
+
+	fusb302_int_default: fusb302-int-default-state {
+		pins = "gpio9";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-up;
+	};
 };
 
 &usb3 {
+	dr_mode = "otg";
 	status = "okay";
+};
+
+&usb_dwc3_hs {
+	remote-endpoint = <&fusb302_hs>;
 };
 
 &wcnss {

--- a/drivers/power/supply/qcom-smbchg.c
+++ b/drivers/power/supply/qcom-smbchg.c
@@ -114,190 +114,6 @@ static int smbchg_usb_enable(struct smbchg_chip *chip, bool enable)
 	return ret;
 }
 
-static int smbchg_usb_path_for_otg(struct smbchg_chip *chip, bool enable)
-{
-	int ret, restore_ret;
-
-	if (enable) {
-		if (chip->otg_usb_path_configured)
-			return 0;
-
-		ret = regmap_read(chip->regmap,
-				  chip->base + SMBCHG_USB_CHGPTH_CFG,
-				  &chip->otg_original_usb_cfg);
-		if (ret) {
-			dev_err(chip->dev,
-				"Failed to read USB charge path config: %pe\n",
-				ERR_PTR(ret));
-			return ret;
-		}
-
-		ret = regmap_read(chip->regmap,
-				  chip->base + SMBCHG_USB_CHGPTH_USBIN_CHGR_CFG,
-				  &chip->otg_original_usbin_chgr_cfg);
-		if (ret) {
-			dev_err(chip->dev,
-				"Failed to read USBIN charger config: %pe\n",
-				ERR_PTR(ret));
-			return ret;
-		}
-
-		ret = qcom_pmic_sec_masked_write(
-			chip->regmap, chip->base + SMBCHG_USB_CHGPTH_CFG,
-			HVDCP_EN_BIT, 0);
-		if (ret) {
-			dev_err(chip->dev,
-				"Failed to disable HVDCP during OTG: %pe\n",
-				ERR_PTR(ret));
-			return ret;
-		}
-
-		ret = qcom_pmic_sec_masked_write(
-			chip->regmap,
-			chip->base + SMBCHG_USB_CHGPTH_USBIN_CHGR_CFG,
-			0xff, USBIN_ADAPTER_9V);
-		if (ret) {
-			dev_err(chip->dev,
-				"Failed to set USBIN allowance for OTG: %pe\n",
-				ERR_PTR(ret));
-
-			restore_ret = qcom_pmic_sec_masked_write(
-				chip->regmap,
-				chip->base + SMBCHG_USB_CHGPTH_CFG,
-				HVDCP_EN_BIT,
-				chip->otg_original_usb_cfg & HVDCP_EN_BIT);
-			if (restore_ret)
-				dev_err(chip->dev,
-					"Failed to restore USB config after OTG setup failure: %pe\n",
-					ERR_PTR(restore_ret));
-
-			return ret;
-		}
-
-		chip->otg_usb_path_configured = true;
-		return 0;
-	}
-
-	if (!chip->otg_usb_path_configured)
-		return 0;
-
-	ret = qcom_pmic_sec_masked_write(
-		chip->regmap, chip->base + SMBCHG_USB_CHGPTH_USBIN_CHGR_CFG,
-		0xff, chip->otg_original_usbin_chgr_cfg & 0xff);
-	if (ret)
-		dev_err(chip->dev,
-			"Failed to restore USBIN charger config after OTG: %pe\n",
-			ERR_PTR(ret));
-
-	restore_ret = qcom_pmic_sec_masked_write(
-		chip->regmap, chip->base + SMBCHG_USB_CHGPTH_CFG,
-		HVDCP_EN_BIT, chip->otg_original_usb_cfg & HVDCP_EN_BIT);
-	if (restore_ret)
-		dev_err(chip->dev,
-			"Failed to restore USB charge path config after OTG: %pe\n",
-			ERR_PTR(restore_ret));
-
-	if (!ret && !restore_ret)
-		chip->otg_usb_path_configured = false;
-
-	return ret ?: restore_ret;
-}
-
-static int smbchg_otg_hw_for_boost(struct smbchg_chip *chip, bool enable)
-{
-	int ret, restore_ret;
-
-	if (enable) {
-		if (chip->otg_hw_configured)
-			return 0;
-
-		ret = regmap_read(chip->regmap,
-				  chip->base + SMBCHG_OTG_OTG_CFG,
-				  &chip->otg_original_otg_cfg);
-		if (ret) {
-			dev_err(chip->dev,
-				"Failed to read OTG config: %pe\n",
-				ERR_PTR(ret));
-			return ret;
-		}
-
-		ret = regmap_read(chip->regmap,
-				  chip->base + SMBCHG_OTG_ICFG,
-				  &chip->otg_original_otg_icfg);
-		if (ret) {
-			dev_err(chip->dev,
-				"Failed to read OTG current config: %pe\n",
-				ERR_PTR(ret));
-			return ret;
-		}
-
-		/*
-		 * Android treats PMI8950 as SCHG_LITE for OTG boost. Apply this
-		 * only while sourcing VBUS so charger/sink mode can keep the PMIC
-		 * default OTG configuration.
-		 */
-		ret = qcom_pmic_sec_masked_write(
-			chip->regmap, chip->base + SMBCHG_OTG_OTG_CFG,
-			OTG_HICCUP_ENABLED_BIT, OTG_HICCUP_ENABLED_BIT);
-		if (ret) {
-			dev_err(chip->dev,
-				"Failed to enable OTG hiccup mode: %pe\n",
-				ERR_PTR(ret));
-			return ret;
-		}
-
-		ret = qcom_pmic_sec_masked_write(
-			chip->regmap, chip->base + SMBCHG_OTG_OTG_CFG,
-			OTG_EN_CTRL_MASK, OTG_CMD_CTRL_RID_EN);
-		if (ret) {
-			dev_err(chip->dev,
-				"Failed to configure OTG command control: %pe\n",
-				ERR_PTR(ret));
-			goto restore_cfg;
-		}
-
-		ret = qcom_pmic_sec_masked_write(
-			chip->regmap, chip->base + SMBCHG_OTG_ICFG,
-			OTG_ILIMIT_MASK, OTG_ILIMIT_1000MA);
-		if (ret) {
-			dev_err(chip->dev,
-				"Failed to configure OTG current limit: %pe\n",
-				ERR_PTR(ret));
-			goto restore_cfg;
-		}
-
-		chip->otg_hw_configured = true;
-		return 0;
-	}
-
-	if (!chip->otg_hw_configured)
-		return 0;
-
-	ret = qcom_pmic_sec_masked_write(
-		chip->regmap, chip->base + SMBCHG_OTG_ICFG,
-		OTG_ILIMIT_MASK,
-		chip->otg_original_otg_icfg & OTG_ILIMIT_MASK);
-	if (ret)
-		dev_err(chip->dev,
-			"Failed to restore OTG current config after OTG: %pe\n",
-			ERR_PTR(ret));
-
-restore_cfg:
-	restore_ret = qcom_pmic_sec_masked_write(
-		chip->regmap, chip->base + SMBCHG_OTG_OTG_CFG,
-		OTG_HICCUP_ENABLED_BIT | OTG_EN_CTRL_MASK,
-		chip->otg_original_otg_cfg &
-			(OTG_HICCUP_ENABLED_BIT | OTG_EN_CTRL_MASK));
-	if (restore_ret)
-		dev_err(chip->dev,
-			"Failed to restore OTG config after OTG: %pe\n",
-			ERR_PTR(restore_ret));
-
-	if (!ret && !restore_ret)
-		chip->otg_hw_configured = false;
-
-	return ret ?: restore_ret;
-}
 
 /**
  * @brief smbchg_usb_get_type() - Get USB port type
@@ -558,12 +374,18 @@ static int smbchg_usb_set_ilim(struct smbchg_chip *chip, int current_ua)
 	size_t i;
 	int ret;
 
-	/*
-	 * Disable USB charge path if the requested current limit is
-	 * lower than the minimum supported limit.
-	 */
-	if (current_ua < smbchg_lc_ilim_options[0])
+	if (current_ua < smbchg_lc_ilim_options[0]) {
+		enum power_supply_usb_type usb_type = smbchg_usb_get_type(chip);
+
+		if (usb_type == POWER_SUPPLY_USB_TYPE_DCP ||
+		    usb_type == POWER_SUPPLY_USB_TYPE_CDP) {
+			dev_dbg(chip->dev, "Ignoring low current limit %duA for wall charger (DCP/CDP)\n",
+				current_ua);
+			return 0;
+		}
+
 		return smbchg_usb_enable(chip, false);
+	}
 
 	/*
 	 * Use LC mode if the requested current limit matches one of
@@ -925,133 +747,12 @@ static int smbchg_otg_switch(struct smbchg_chip *chip, bool enable)
 	dev_dbg(chip->dev, "%sabling OTG VBUS regulator",
 			enable ? "En" : "Dis");
 
-	if (enable && !chip->otg_usb_input_suspended) {
-		ret = smbchg_usb_enable(chip, false);
-		if (ret) {
-			dev_err(chip->dev,
-				"Failed to suspend USB input before OTG: %d\n",
-				ret);
-			return ret;
-		}
-
-		chip->otg_usb_input_suspended = true;
-		msleep(20);
-	}
-
-	if (enable) {
-		ret = smbchg_usb_path_for_otg(chip, true);
-		if (ret) {
-			if (chip->otg_usb_input_suspended) {
-				int usb_ret;
-
-				usb_ret = smbchg_usb_enable(chip, true);
-				if (usb_ret)
-					dev_err(chip->dev,
-						"Failed to restore USB input after OTG setup failure: %d\n",
-						usb_ret);
-				else
-					chip->otg_usb_input_suspended = false;
-			}
-
-			return ret;
-		}
-
-		msleep(20);
-
-		ret = smbchg_otg_hw_for_boost(chip, true);
-		if (ret) {
-			smbchg_usb_path_for_otg(chip, false);
-			if (chip->otg_usb_input_suspended) {
-				int usb_ret;
-
-				usb_ret = smbchg_usb_enable(chip, true);
-				if (usb_ret)
-					dev_err(chip->dev,
-						"Failed to restore USB input after OTG setup failure: %d\n",
-						usb_ret);
-				else
-					chip->otg_usb_input_suspended = false;
-			}
-
-			return ret;
-		}
-
-		msleep(20);
-	}
-
-	if (enable && !chip->otg_pulse_skip_disabled) {
-		ret = qcom_pmic_sec_masked_write(chip->regmap,
-				 chip->base + SMBCHG_OTG_TRIM6,
-				 OTG_TRIM6_TR_ENB_SKIP_BIT,
-				 OTG_TRIM6_TR_ENB_SKIP_BIT);
-		if (ret) {
-				dev_err(chip->dev,
-					"Failed to disable OTG pulse skip: %d\n", ret);
-			smbchg_otg_hw_for_boost(chip, false);
-			smbchg_usb_path_for_otg(chip, false);
-			if (chip->otg_usb_input_suspended) {
-				int usb_ret;
-
-				usb_ret = smbchg_usb_enable(chip, true);
-				if (usb_ret)
-					dev_err(chip->dev,
-						"Failed to restore USB input after OTG setup failure: %d\n",
-						usb_ret);
-				else
-					chip->otg_usb_input_suspended = false;
-			}
-			return ret;
-		}
-
-		chip->otg_pulse_skip_disabled = true;
-		msleep(20);
-	}
-
 	ret = regmap_update_bits(chip->regmap,
 				 chip->base + SMBCHG_BAT_IF_CMD_CHG, OTG_EN_BIT,
 				 enable ? OTG_EN_BIT : 0);
 	if (ret)
 		dev_err(chip->dev, "Failed to %sable OTG regulator: %d\n",
 			enable ? "en" : "dis", ret);
-
-	if (!enable && chip->otg_hw_configured) {
-		int hw_ret;
-
-		hw_ret = smbchg_otg_hw_for_boost(chip, false);
-		if (hw_ret && !ret)
-			ret = hw_ret;
-	}
-
-	if (!enable && chip->otg_usb_path_configured) {
-		int path_ret;
-
-		path_ret = smbchg_usb_path_for_otg(chip, false);
-		if (path_ret && !ret)
-			ret = path_ret;
-	}
-
-	if (!enable && chip->otg_usb_input_suspended) {
-		int usb_ret;
-
-		usb_ret = smbchg_usb_enable(chip, true);
-		if (usb_ret)
-			dev_err(chip->dev,
-				"Failed to restore USB input after OTG: %d\n",
-				usb_ret);
-		else
-			chip->otg_usb_input_suspended = false;
-	}
-
-	if (!ret && !enable && chip->otg_pulse_skip_disabled) {
-		ret = qcom_pmic_sec_masked_write(chip->regmap,
-				 chip->base + SMBCHG_OTG_TRIM6,
-				 OTG_TRIM6_TR_ENB_SKIP_BIT, 0);
-		if (ret)
-			dev_err(chip->dev,
-				"Failed to enable OTG pulse skip: %d\n", ret);
-		else
-			chip->otg_pulse_skip_disabled = false;
-	}
 
 	return ret;
 }
@@ -1435,14 +1136,13 @@ static irqreturn_t smbchg_handle_aicl_done(int irq, void *data)
 {
 	struct smbchg_chip *chip = data;
 	int ilim;
-	int ret;
 
 	dev_dbg(chip->dev, "AICL done");
 
 	ilim = smbchg_usb_get_ilim(chip);
 	if (ilim < 0)
 		dev_warn(chip->dev, "Failed to read AICL result: %pe\n",
-			 ERR_PTR(ret));
+			 ERR_PTR(ilim));
 	else
 		dev_dbg(chip->dev, "AICL result: %uuA", ilim);
 
@@ -1800,7 +1500,7 @@ static int smbchg_init(struct smbchg_chip *chip)
 		chip->regmap, chip->base + SMBCHG_CHGR_CHGR_CFG2,
 		CHARGER_INHIBIT_BIT | AUTO_RECHG_BIT | I_TERM_BIT |
 			P2F_CHG_TRAN_BIT | CHG_EN_SRC_BIT,
-		CHG_INHIBIT_DIS | AUTO_RCHG_EN | CURRENT_TERM_EN |
+		CHG_INHIBIT_EN | AUTO_RCHG_EN | CURRENT_TERM_EN |
 			PRE_FAST_AUTO | CHG_EN_SRC_CMD);
 	if (ret)
 		return ret;
@@ -1889,6 +1589,48 @@ static int smbchg_init(struct smbchg_chip *chip)
 	 * and enable the charge path if USB is present.
 	 */
 	smbchg_handle_usb_source_detect(0, chip);
+
+	if (chip->smbchg_lite) {
+		ret = qcom_pmic_sec_masked_write(
+			chip->regmap, chip->base + SMBCHG_OTG_OTG_CFG,
+			OTG_HICCUP_ENABLED_BIT, OTG_HICCUP_ENABLED_BIT);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to enable OTG hiccup mode: %pe\n",
+				ERR_PTR(ret));
+			return ret;
+		}
+
+		ret = qcom_pmic_sec_masked_write(
+			chip->regmap, chip->base + SMBCHG_OTG_OTG_CFG,
+			OTG_EN_CTRL_MASK, OTG_CMD_CTRL_RID_EN);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to configure OTG command control: %pe\n",
+				ERR_PTR(ret));
+			return ret;
+		}
+
+		ret = qcom_pmic_sec_masked_write(
+			chip->regmap, chip->base + SMBCHG_OTG_ICFG,
+			OTG_ILIMIT_MASK, OTG_ILIMIT_1000MA);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to configure OTG current limit: %pe\n",
+				ERR_PTR(ret));
+			return ret;
+		}
+
+		ret = qcom_pmic_sec_masked_write(
+			chip->regmap, chip->base + SMBCHG_OTG_TRIM6,
+			OTG_TRIM6_TR_ENB_SKIP_BIT, OTG_TRIM6_TR_ENB_SKIP_BIT);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to disable OTG pulse skip: %pe\n",
+				ERR_PTR(ret));
+			return ret;
+		}
+	}
 
 	return 0;
 }

--- a/drivers/power/supply/qcom-smbchg.c
+++ b/drivers/power/supply/qcom-smbchg.c
@@ -16,6 +16,7 @@
 #include <linux/of_irq.h>
 #include <linux/interrupt.h>
 #include <linux/cleanup.h>
+#include <linux/delay.h>
 #include <linux/mutex.h>
 #include <linux/platform_device.h>
 #include <linux/power_supply.h>
@@ -52,6 +53,7 @@
 	(__fcs_i - 1);							\
 })
 
+#define SDP_CURRENT_UA 500000
 
 /**
  * @brief smbchg_usb_is_present() - Check for USB presence
@@ -110,6 +112,191 @@ static int smbchg_usb_enable(struct smbchg_chip *chip, bool enable)
 			enable ? "en" : "dis", ERR_PTR(ret));
 
 	return ret;
+}
+
+static int smbchg_usb_path_for_otg(struct smbchg_chip *chip, bool enable)
+{
+	int ret, restore_ret;
+
+	if (enable) {
+		if (chip->otg_usb_path_configured)
+			return 0;
+
+		ret = regmap_read(chip->regmap,
+				  chip->base + SMBCHG_USB_CHGPTH_CFG,
+				  &chip->otg_original_usb_cfg);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to read USB charge path config: %pe\n",
+				ERR_PTR(ret));
+			return ret;
+		}
+
+		ret = regmap_read(chip->regmap,
+				  chip->base + SMBCHG_USB_CHGPTH_USBIN_CHGR_CFG,
+				  &chip->otg_original_usbin_chgr_cfg);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to read USBIN charger config: %pe\n",
+				ERR_PTR(ret));
+			return ret;
+		}
+
+		ret = qcom_pmic_sec_masked_write(
+			chip->regmap, chip->base + SMBCHG_USB_CHGPTH_CFG,
+			HVDCP_EN_BIT, 0);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to disable HVDCP during OTG: %pe\n",
+				ERR_PTR(ret));
+			return ret;
+		}
+
+		ret = qcom_pmic_sec_masked_write(
+			chip->regmap,
+			chip->base + SMBCHG_USB_CHGPTH_USBIN_CHGR_CFG,
+			0xff, USBIN_ADAPTER_9V);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to set USBIN allowance for OTG: %pe\n",
+				ERR_PTR(ret));
+
+			restore_ret = qcom_pmic_sec_masked_write(
+				chip->regmap,
+				chip->base + SMBCHG_USB_CHGPTH_CFG,
+				HVDCP_EN_BIT,
+				chip->otg_original_usb_cfg & HVDCP_EN_BIT);
+			if (restore_ret)
+				dev_err(chip->dev,
+					"Failed to restore USB config after OTG setup failure: %pe\n",
+					ERR_PTR(restore_ret));
+
+			return ret;
+		}
+
+		chip->otg_usb_path_configured = true;
+		return 0;
+	}
+
+	if (!chip->otg_usb_path_configured)
+		return 0;
+
+	ret = qcom_pmic_sec_masked_write(
+		chip->regmap, chip->base + SMBCHG_USB_CHGPTH_USBIN_CHGR_CFG,
+		0xff, chip->otg_original_usbin_chgr_cfg & 0xff);
+	if (ret)
+		dev_err(chip->dev,
+			"Failed to restore USBIN charger config after OTG: %pe\n",
+			ERR_PTR(ret));
+
+	restore_ret = qcom_pmic_sec_masked_write(
+		chip->regmap, chip->base + SMBCHG_USB_CHGPTH_CFG,
+		HVDCP_EN_BIT, chip->otg_original_usb_cfg & HVDCP_EN_BIT);
+	if (restore_ret)
+		dev_err(chip->dev,
+			"Failed to restore USB charge path config after OTG: %pe\n",
+			ERR_PTR(restore_ret));
+
+	if (!ret && !restore_ret)
+		chip->otg_usb_path_configured = false;
+
+	return ret ?: restore_ret;
+}
+
+static int smbchg_otg_hw_for_boost(struct smbchg_chip *chip, bool enable)
+{
+	int ret, restore_ret;
+
+	if (enable) {
+		if (chip->otg_hw_configured)
+			return 0;
+
+		ret = regmap_read(chip->regmap,
+				  chip->base + SMBCHG_OTG_OTG_CFG,
+				  &chip->otg_original_otg_cfg);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to read OTG config: %pe\n",
+				ERR_PTR(ret));
+			return ret;
+		}
+
+		ret = regmap_read(chip->regmap,
+				  chip->base + SMBCHG_OTG_ICFG,
+				  &chip->otg_original_otg_icfg);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to read OTG current config: %pe\n",
+				ERR_PTR(ret));
+			return ret;
+		}
+
+		/*
+		 * Android treats PMI8950 as SCHG_LITE for OTG boost. Apply this
+		 * only while sourcing VBUS so charger/sink mode can keep the PMIC
+		 * default OTG configuration.
+		 */
+		ret = qcom_pmic_sec_masked_write(
+			chip->regmap, chip->base + SMBCHG_OTG_OTG_CFG,
+			OTG_HICCUP_ENABLED_BIT, OTG_HICCUP_ENABLED_BIT);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to enable OTG hiccup mode: %pe\n",
+				ERR_PTR(ret));
+			return ret;
+		}
+
+		ret = qcom_pmic_sec_masked_write(
+			chip->regmap, chip->base + SMBCHG_OTG_OTG_CFG,
+			OTG_EN_CTRL_MASK, OTG_CMD_CTRL_RID_EN);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to configure OTG command control: %pe\n",
+				ERR_PTR(ret));
+			goto restore_cfg;
+		}
+
+		ret = qcom_pmic_sec_masked_write(
+			chip->regmap, chip->base + SMBCHG_OTG_ICFG,
+			OTG_ILIMIT_MASK, OTG_ILIMIT_1000MA);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to configure OTG current limit: %pe\n",
+				ERR_PTR(ret));
+			goto restore_cfg;
+		}
+
+		chip->otg_hw_configured = true;
+		return 0;
+	}
+
+	if (!chip->otg_hw_configured)
+		return 0;
+
+	ret = qcom_pmic_sec_masked_write(
+		chip->regmap, chip->base + SMBCHG_OTG_ICFG,
+		OTG_ILIMIT_MASK,
+		chip->otg_original_otg_icfg & OTG_ILIMIT_MASK);
+	if (ret)
+		dev_err(chip->dev,
+			"Failed to restore OTG current config after OTG: %pe\n",
+			ERR_PTR(ret));
+
+restore_cfg:
+	restore_ret = qcom_pmic_sec_masked_write(
+		chip->regmap, chip->base + SMBCHG_OTG_OTG_CFG,
+		OTG_HICCUP_ENABLED_BIT | OTG_EN_CTRL_MASK,
+		chip->otg_original_otg_cfg &
+			(OTG_HICCUP_ENABLED_BIT | OTG_EN_CTRL_MASK));
+	if (restore_ret)
+		dev_err(chip->dev,
+			"Failed to restore OTG config after OTG: %pe\n",
+			ERR_PTR(restore_ret));
+
+	if (!ret && !restore_ret)
+		chip->otg_hw_configured = false;
+
+	return ret ?: restore_ret;
 }
 
 /**
@@ -738,12 +925,133 @@ static int smbchg_otg_switch(struct smbchg_chip *chip, bool enable)
 	dev_dbg(chip->dev, "%sabling OTG VBUS regulator",
 			enable ? "En" : "Dis");
 
+	if (enable && !chip->otg_usb_input_suspended) {
+		ret = smbchg_usb_enable(chip, false);
+		if (ret) {
+			dev_err(chip->dev,
+				"Failed to suspend USB input before OTG: %d\n",
+				ret);
+			return ret;
+		}
+
+		chip->otg_usb_input_suspended = true;
+		msleep(20);
+	}
+
+	if (enable) {
+		ret = smbchg_usb_path_for_otg(chip, true);
+		if (ret) {
+			if (chip->otg_usb_input_suspended) {
+				int usb_ret;
+
+				usb_ret = smbchg_usb_enable(chip, true);
+				if (usb_ret)
+					dev_err(chip->dev,
+						"Failed to restore USB input after OTG setup failure: %d\n",
+						usb_ret);
+				else
+					chip->otg_usb_input_suspended = false;
+			}
+
+			return ret;
+		}
+
+		msleep(20);
+
+		ret = smbchg_otg_hw_for_boost(chip, true);
+		if (ret) {
+			smbchg_usb_path_for_otg(chip, false);
+			if (chip->otg_usb_input_suspended) {
+				int usb_ret;
+
+				usb_ret = smbchg_usb_enable(chip, true);
+				if (usb_ret)
+					dev_err(chip->dev,
+						"Failed to restore USB input after OTG setup failure: %d\n",
+						usb_ret);
+				else
+					chip->otg_usb_input_suspended = false;
+			}
+
+			return ret;
+		}
+
+		msleep(20);
+	}
+
+	if (enable && !chip->otg_pulse_skip_disabled) {
+		ret = qcom_pmic_sec_masked_write(chip->regmap,
+				 chip->base + SMBCHG_OTG_TRIM6,
+				 OTG_TRIM6_TR_ENB_SKIP_BIT,
+				 OTG_TRIM6_TR_ENB_SKIP_BIT);
+		if (ret) {
+				dev_err(chip->dev,
+					"Failed to disable OTG pulse skip: %d\n", ret);
+			smbchg_otg_hw_for_boost(chip, false);
+			smbchg_usb_path_for_otg(chip, false);
+			if (chip->otg_usb_input_suspended) {
+				int usb_ret;
+
+				usb_ret = smbchg_usb_enable(chip, true);
+				if (usb_ret)
+					dev_err(chip->dev,
+						"Failed to restore USB input after OTG setup failure: %d\n",
+						usb_ret);
+				else
+					chip->otg_usb_input_suspended = false;
+			}
+			return ret;
+		}
+
+		chip->otg_pulse_skip_disabled = true;
+		msleep(20);
+	}
+
 	ret = regmap_update_bits(chip->regmap,
 				 chip->base + SMBCHG_BAT_IF_CMD_CHG, OTG_EN_BIT,
 				 enable ? OTG_EN_BIT : 0);
 	if (ret)
 		dev_err(chip->dev, "Failed to %sable OTG regulator: %d\n",
 			enable ? "en" : "dis", ret);
+
+	if (!enable && chip->otg_hw_configured) {
+		int hw_ret;
+
+		hw_ret = smbchg_otg_hw_for_boost(chip, false);
+		if (hw_ret && !ret)
+			ret = hw_ret;
+	}
+
+	if (!enable && chip->otg_usb_path_configured) {
+		int path_ret;
+
+		path_ret = smbchg_usb_path_for_otg(chip, false);
+		if (path_ret && !ret)
+			ret = path_ret;
+	}
+
+	if (!enable && chip->otg_usb_input_suspended) {
+		int usb_ret;
+
+		usb_ret = smbchg_usb_enable(chip, true);
+		if (usb_ret)
+			dev_err(chip->dev,
+				"Failed to restore USB input after OTG: %d\n",
+				usb_ret);
+		else
+			chip->otg_usb_input_suspended = false;
+	}
+
+	if (!ret && !enable && chip->otg_pulse_skip_disabled) {
+		ret = qcom_pmic_sec_masked_write(chip->regmap,
+				 chip->base + SMBCHG_OTG_TRIM6,
+				 OTG_TRIM6_TR_ENB_SKIP_BIT, 0);
+		if (ret)
+			dev_err(chip->dev,
+				"Failed to enable OTG pulse skip: %d\n", ret);
+		else
+			chip->otg_pulse_skip_disabled = false;
+	}
 
 	return ret;
 }
@@ -918,13 +1226,24 @@ static void smbchg_detect_work(struct work_struct *work)
 		smbchg_otg_switch(chip, false);
 
 	/*
-	 * Prepare for running AICL to find a suitable input current
-	 * limit if connected to a DCP or a CDP
+	 * SDPs need the dedicated low-current USB 2.0 full-current mode.
+	 * Leaving the charger in HC/AICL mode can keep a stale high-current
+	 * limit from a previous charger and results in a present-but-weak PC
+	 * charge path.
 	 */
-	if (usb_present && (usb_type == POWER_SUPPLY_USB_TYPE_DCP ||
-			    usb_type == POWER_SUPPLY_USB_TYPE_CDP)) {
+	if (usb_present && !otg_present &&
+	    usb_type == POWER_SUPPLY_USB_TYPE_SDP) {
+		ret = smbchg_usb_set_ilim(chip, SDP_CURRENT_UA);
+		if (ret < 0) {
+			dev_err(chip->dev,
+				"Failed to set SDP input current limit: %pe\n",
+				ERR_PTR(ret));
+			return;
+		}
+	} else if (usb_present && (usb_type == POWER_SUPPLY_USB_TYPE_DCP ||
+				   usb_type == POWER_SUPPLY_USB_TYPE_CDP)) {
 		/*
-		 * Enable AICL to find a suitable current limit for the
+		 * Prepare AICL to find a suitable input current limit for the
 		 * newly plugged into port.
 		 */
 		ret = smbchg_usb_aicl_enable(chip);
@@ -1481,7 +1800,7 @@ static int smbchg_init(struct smbchg_chip *chip)
 		chip->regmap, chip->base + SMBCHG_CHGR_CHGR_CFG2,
 		CHARGER_INHIBIT_BIT | AUTO_RECHG_BIT | I_TERM_BIT |
 			P2F_CHG_TRAN_BIT | CHG_EN_SRC_BIT,
-		CHG_INHIBIT_EN | AUTO_RCHG_EN | CURRENT_TERM_EN |
+		CHG_INHIBIT_DIS | AUTO_RCHG_EN | CURRENT_TERM_EN |
 			PRE_FAST_AUTO | CHG_EN_SRC_CMD);
 	if (ret)
 		return ret;

--- a/drivers/power/supply/qcom-smbchg.h
+++ b/drivers/power/supply/qcom-smbchg.h
@@ -265,14 +265,7 @@ struct smbchg_chip {
 	struct regulator_desc otg_rdesc;
 	struct regulator_dev *otg_reg;
 	int otg_resets;
-	bool otg_pulse_skip_disabled;
-	bool otg_usb_input_suspended;
-	bool otg_usb_path_configured;
-	unsigned int otg_original_usb_cfg;
-	unsigned int otg_original_usbin_chgr_cfg;
-	bool otg_hw_configured;
-	unsigned int otg_original_otg_cfg;
-	unsigned int otg_original_otg_icfg;
+
 
 	struct extcon_dev *edev;
 

--- a/drivers/power/supply/qcom-smbchg.h
+++ b/drivers/power/supply/qcom-smbchg.h
@@ -21,6 +21,7 @@
 /* OTG */
 #define SMBCHG_OTG_RT_STS			0x110
 #define SMBCHG_OTG_OTG_CFG			0x1f1
+#define SMBCHG_OTG_ICFG			0x1f3
 #define SMBCHG_OTG_TRIM6			0x1f6
 #define SMBCHG_OTG_LOW_PWR_OPTIONS		0x1ff
 
@@ -112,6 +113,16 @@
 #define OTG_EN_BIT			BIT(0)
 #define CHG_EN_BIT			BIT(1)
 
+/* OTG_CFG bits */
+#define OTG_HICCUP_ENABLED_BIT		BIT(6)
+#define OTG_EN_CTRL_MASK		GENMASK(3, 2)
+
+/* OTG_ICFG bits */
+#define OTG_ILIMIT_MASK			GENMASK(1, 0)
+
+/* OTG_TRIM6 bits */
+#define OTG_TRIM6_TR_ENB_SKIP_BIT	BIT(2)
+
 /* BAT_IF_RT_STS bits */
 #define HOT_BAT_HARD_BIT		BIT(0)
 #define HOT_BAT_SOFT_BIT		BIT(1)
@@ -130,6 +141,7 @@
 /* USB_CHGPTH_CFG bits */
 #define USB51AC_CTRL			BIT(1)
 #define USB51_COMMAND_POL		BIT(2)
+#define HVDCP_EN_BIT			BIT(3)
 #define CFG_USB3P0_SEL_BIT		BIT(7)
 
 /* USB_CHGPTH_RT_STS bits */
@@ -154,6 +166,9 @@
 /* USB_CHGPTH_APSD_CFG bits */
 #define USB_CHGPTH_APSD_EN		BIT(0)
 
+/* USB_CHGPTH_USBIN_CHGR_CFG values */
+#define USBIN_ADAPTER_9V		0x3
+
 /* MISC_IDEV_STS bits */
 #define FMB_STS_MASK			GENMASK(3, 0)
 
@@ -163,6 +178,12 @@
 #define AICL_RERUN_USB_BIT		BIT(5)
 
 /* Values */
+/* OTG_CFG values */
+#define OTG_CMD_CTRL_RID_EN		BIT(3)
+
+/* OTG_ICFG values */
+#define OTG_ILIMIT_1000MA		GENMASK(1, 0)
+
 /* CHGR_STS values */
 #define CHG_TYPE_SHIFT			1
 #define BATT_NOT_CHG_VAL		0x0
@@ -244,6 +265,14 @@ struct smbchg_chip {
 	struct regulator_desc otg_rdesc;
 	struct regulator_dev *otg_reg;
 	int otg_resets;
+	bool otg_pulse_skip_disabled;
+	bool otg_usb_input_suspended;
+	bool otg_usb_path_configured;
+	unsigned int otg_original_usb_cfg;
+	unsigned int otg_original_usbin_chgr_cfg;
+	bool otg_hw_configured;
+	unsigned int otg_original_otg_cfg;
+	unsigned int otg_original_otg_icfg;
 
 	struct extcon_dev *edev;
 


### PR DESCRIPTION
Enable USB-C OTG host mode on the Motorola Moto G6 (`motorola-ali`).

The DTS change describes the FUSB302 Type-C controller and models VBUS like the
downstream Android device tree: a fixed `usb_otg_vreg` regulator fed by the
SMBCHG OTG regulator, without the unused GPIO109 gate.

The SMBCHG change provides the missing PMI8950/SCHG_LITE OTG setup needed for
physical VBUS. DTS-only probing can reach source/host state, but passive OTG
devices remain unpowered without the charger boost register setup.

Tested on a Moto G6:

- PC/gadget charging: sink/device, SDP, 500 mA
- Wall charging: DCP, 3 A
- Passive OTG host: source/host, xHCI root hubs, USB storage enumeration

Generated against `6.19.5/main`.