### PR TITLE
arm64: dts: qcom: sdm632-fairphone-fp3: Enable venus

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm632-fairphone-fp3.dts
+++ b/arch/arm64/boot/dts/qcom/sdm632-fairphone-fp3.dts
@@ -510,6 +510,12 @@
 	remote-endpoint = <&pmi632_hs_in>;
 };
 
+&venus {
+	firmware-name = "qcom/msm8953/fairphone/fp3/venus.mbn";
+
+	status = "okay";
+};
+
 &wcnss {
 	firmware-name = "qcom/msm8953/fairphone/fp3/wcnss.mbn";
 	vddpx-supply = <&pm8953_l5>;


### PR DESCRIPTION
Set an appropriate firmware-name for venus and enable it.

---

Venus seems to probe successfully, is there anything more I should test? I know of the "fluster" test suite, but I wonder how much will succeed on this older SoC.