### PR TITLE
xiaomi-onclite: Add touchscreen support for Goodix variant

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm632-xiaomi-onclite.dts
+++ b/arch/arm64/boot/dts/qcom/sdm632-xiaomi-onclite.dts
@@ -148,8 +148,9 @@
 &i2c_3 {
 	status = "okay";
 
+	/* Goodix variant - disabled by default */
 	touchscreen@14 {
-		compatible = "goodix,gt1x";
+		compatible = "goodix,gt1151";
 		reg = <0x14>;
 
 		interrupt-parent = <&tlmm>;
@@ -168,10 +169,9 @@
 		touchscreen-size-x = <720>;
 		touchscreen-size-y = <1520>;
 
-		status = "okay";
+		status = "disabled";
 	};
 
-	/* Focaltech variant - disabled by default for Goodix units */
 	touchscreen@38 {
 		compatible = "edt,edt-ft5406";
 		reg = <0x38>;
@@ -191,7 +191,7 @@
 		touchscreen-size-x = <720>;
 		touchscreen-size-y = <1520>;
 
-		status = "disabled";
+		status = "okay";
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/sdm632-xiaomi-onclite.dts
+++ b/arch/arm64/boot/dts/qcom/sdm632-xiaomi-onclite.dts
@@ -148,6 +148,30 @@
 &i2c_3 {
 	status = "okay";
 
+	touchscreen@14 {
+		compatible = "goodix,gt1x";
+		reg = <0x14>;
+
+		interrupt-parent = <&tlmm>;
+		interrupts = <65 IRQ_TYPE_EDGE_FALLING>;
+
+		irq-gpios = <&tlmm 65 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&tlmm 64 GPIO_ACTIVE_LOW>;
+
+		pinctrl-0 = <&ts_reset_active &ts_int_active>;
+		pinctrl-1 = <&ts_reset_suspend &ts_int_suspend>;
+		pinctrl-names = "default", "sleep";
+
+		vdd-supply = <&pm8953_l10>;
+		iovcc-supply = <&pm8953_l6>;
+
+		touchscreen-size-x = <720>;
+		touchscreen-size-y = <1520>;
+
+		status = "okay";
+	};
+
+	/* Focaltech variant - disabled by default for Goodix units */
 	touchscreen@38 {
 		compatible = "edt,edt-ft5406";
 		reg = <0x38>;
@@ -167,7 +191,7 @@
 		touchscreen-size-x = <720>;
 		touchscreen-size-y = <1520>;
 
-		status = "okay";
+		status = "disabled";
 	};
 };
 


### PR DESCRIPTION
This is my first time contributing upstream; go easy on me as I learn my way around :slightly_smiling_face:

I'd like to figure out if there's a way to have both the Focaltech and Goodix variants work out-of-the-box: I imagine this would require changes to lk2nd, so if anyone could point me in the right direction it'd be greatly appreciated.