### PR TITLE
Revert "arm64: dts: qcom: sdm632-fairphone-fp3: Enable venus"

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm632-fairphone-fp3.dts
+++ b/arch/arm64/boot/dts/qcom/sdm632-fairphone-fp3.dts
@@ -510,12 +510,6 @@
 	remote-endpoint = <&pmi632_hs_in>;
 };
 
-&venus {
-	firmware-name = "qcom/msm8953/fairphone/fp3/venus.mbn";
-
-	status = "okay";
-};
-
 &wcnss {
 	firmware-name = "qcom/msm8953/fairphone/fp3/wcnss.mbn";
 	vddpx-supply = <&pm8953_l5>;


### PR DESCRIPTION
Reverts msm8953-mainline/linux#247

There is no venus label, yet.